### PR TITLE
Add support for case-insensitive link tag detection in findMetaFeeds

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -462,9 +462,9 @@ function findMetaFeedsWithStringParsing(
     }
   };
 
-  // Split HTML by both <link and <LINK to find potential feed links (case insensitive)
-  processLinkSections(html.split("<link"));
-  processLinkSections(html.split("<LINK"));
+  // Split HTML by <link tags (case insensitive) to find potential feed links
+  const linkSections = html.split(/<link/gi);
+  processLinkSections(linkSections);
 
   return feeds;
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -445,20 +445,27 @@ function findMetaFeedsWithStringParsing(
   baseUrl: string,
 ): FeedResult[] {
   const feeds: FeedResult[] = [];
+  const foundUrls = new Set<string>();
 
-  // Split HTML by <link to find potential feed links
-  const linkSections = html.split("<link");
-
-  for (let i = 1; i < linkSections.length; i++) {
-    const feed = parseLinkSection(
-      linkSections[i],
-      SUPPORTED_FEED_TYPES,
-      baseUrl,
-    );
-    if (feed) {
-      feeds.push(feed);
+  // Helper function to process link sections
+  const processLinkSections = (linkSections: string[]) => {
+    for (let i = 1; i < linkSections.length; i++) {
+      const feed = parseLinkSection(
+        linkSections[i],
+        SUPPORTED_FEED_TYPES,
+        baseUrl,
+      );
+      if (feed && !foundUrls.has(feed.url)) {
+        foundUrls.add(feed.url);
+        feeds.push(feed);
+      }
     }
-  }
+  };
+
+  // Split HTML by both <link and <LINK to find potential feed links (case insensitive)
+  processLinkSections(html.split("<link"));
+  processLinkSections(html.split("<LINK"));
+
   return feeds;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * フィード検出の際、HTML内の `<link>` タグが大文字の場合でも正しく認識されるようになりました。
  * 重複するフィードURLが検出結果に含まれないよう改善されました。

* **テスト**
  * 大文字の `<LINK>` タグを含むHTMLでのフィード検出を確認するテストが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->