### PR TITLE
Refine security headers by using CSP

### DIFF
--- a/worker/http/cors.test.ts
+++ b/worker/http/cors.test.ts
@@ -34,13 +34,10 @@ describe("http/cors", () => {
       expect(result.headers.get("Access-Control-Allow-Origin")).toBe(
         "http://localhost:5173",
       );
-      expect(result.headers.get("Access-Control-Allow-Methods")).toBe(
-        "POST, OPTIONS",
-      );
-      expect(result.headers.get("Access-Control-Allow-Headers")).toBe(
-        "Content-Type",
-      );
-      expect(result.headers.get("Access-Control-Max-Age")).toBe("86400");
+      // Preflight-only headers should NOT be set on regular responses
+      expect(result.headers.get("Access-Control-Allow-Methods")).toBeNull();
+      expect(result.headers.get("Access-Control-Allow-Headers")).toBeNull();
+      expect(result.headers.get("Access-Control-Max-Age")).toBeNull();
     });
 
     it("should not add CORS headers for disallowed origins", () => {
@@ -54,13 +51,10 @@ describe("http/cors", () => {
       const result = addSecurityHeaders(originalResponse, request);
 
       expect(result.headers.get("Access-Control-Allow-Origin")).toBeNull();
-      expect(result.headers.get("Access-Control-Allow-Methods")).toBe(
-        "POST, OPTIONS",
-      );
-      expect(result.headers.get("Access-Control-Allow-Headers")).toBe(
-        "Content-Type",
-      );
-      expect(result.headers.get("Access-Control-Max-Age")).toBe("86400");
+      // Preflight-only headers should NOT be set on regular responses
+      expect(result.headers.get("Access-Control-Allow-Methods")).toBeNull();
+      expect(result.headers.get("Access-Control-Allow-Headers")).toBeNull();
+      expect(result.headers.get("Access-Control-Max-Age")).toBeNull();
     });
 
     it("should handle requests without origin header", () => {
@@ -70,9 +64,8 @@ describe("http/cors", () => {
       const result = addSecurityHeaders(originalResponse, request);
 
       expect(result.headers.get("Access-Control-Allow-Origin")).toBeNull();
-      expect(result.headers.get("Access-Control-Allow-Methods")).toBe(
-        "POST, OPTIONS",
-      );
+      // Preflight-only headers should NOT be set on regular responses
+      expect(result.headers.get("Access-Control-Allow-Methods")).toBeNull();
     });
 
     it("should work without request parameter", () => {

--- a/worker/http/cors.test.ts
+++ b/worker/http/cors.test.ts
@@ -19,6 +19,7 @@ describe("http/cors", () => {
       expect(csp).toContain("default-src 'none'");
       expect(csp).toContain("script-src 'none'");
       expect(csp).toContain("object-src 'none'");
+      expect(csp).toContain("frame-ancestors 'none'");
     });
 
     it("should add CORS headers for allowed origins", () => {

--- a/worker/http/cors.test.ts
+++ b/worker/http/cors.test.ts
@@ -15,9 +15,10 @@ describe("http/cors", () => {
       expect(result.headers.get("Referrer-Policy")).toBe(
         "strict-origin-when-cross-origin",
       );
-      expect(result.headers.get("Content-Security-Policy")).toBe(
-        "default-src 'none'; script-src 'none'; object-src 'none'; frame-ancestors 'none'",
-      );
+      const csp = result.headers.get("Content-Security-Policy") ?? "";
+      expect(csp).toContain("default-src 'none'");
+      expect(csp).toContain("script-src 'none'");
+      expect(csp).toContain("object-src 'none'");
     });
 
     it("should add CORS headers for allowed origins", () => {

--- a/worker/http/cors.test.ts
+++ b/worker/http/cors.test.ts
@@ -11,12 +11,12 @@ describe("http/cors", () => {
 
       expect(result.status).toBe(200);
       expect(result.headers.get("X-Content-Type-Options")).toBe("nosniff");
-      expect(result.headers.get("X-Frame-Options")).toBe("DENY");
+      expect(result.headers.get("X-Frame-Options")).toBeNull();
       expect(result.headers.get("Referrer-Policy")).toBe(
         "strict-origin-when-cross-origin",
       );
       expect(result.headers.get("Content-Security-Policy")).toBe(
-        "default-src 'none'; script-src 'none'; object-src 'none'",
+        "default-src 'none'; script-src 'none'; object-src 'none'; frame-ancestors 'none'",
       );
     });
 

--- a/worker/http/cors.ts
+++ b/worker/http/cors.ts
@@ -29,11 +29,6 @@ export function addSecurityHeaders(
     if (origin && ALLOWED_ORIGINS.includes(origin)) {
       headers.set("Access-Control-Allow-Origin", origin);
     }
-
-    // Set other CORS headers
-    headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
-    headers.set("Access-Control-Allow-Headers", "Content-Type");
-    headers.set("Access-Control-Max-Age", "86400"); // 24 hours
   }
 
   return new Response(response.body, {

--- a/worker/http/cors.ts
+++ b/worker/http/cors.ts
@@ -12,16 +12,13 @@ export function addSecurityHeaders(
   // Prevent MIME type sniffing
   headers.set("X-Content-Type-Options", "nosniff");
 
-  // Prevent embedding in frames
-  headers.set("X-Frame-Options", "DENY");
-
   // Control referrer information
   headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
 
-  // Basic Content Security Policy
+  // Comprehensive Content Security Policy with frame protection
   headers.set(
     "Content-Security-Policy",
-    "default-src 'none'; script-src 'none'; object-src 'none'",
+    "default-src 'none'; script-src 'none'; object-src 'none'; frame-ancestors 'none'",
   );
 
   // Add CORS headers with proper origin validation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- バグ修正
  - レスポンスのセキュリティヘッダーを更新。X-Frame-Options の送出を停止し、Content-Security-Policy に frame-ancestors 'none' を追加してフレーム埋め込みを禁止。その他（X-Content-Type-Options、Referrer-Policy 等）は維持。
  - 通常レスポンスで CORS のプリフライト専用ヘッダー（Access-Control-Allow-Methods/Headers/Max-Age）を設定しないように変更。

- テスト
  - テスト期待値を更新。CSP は部分一致で検証し、不要になった X-Frame-Options 検証を削除。通常レスポンスにプリフライト専用ヘッダーが含まれないことを確認。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->