### PR TITLE
Add test and implementations for discovering relative feeds from subpaths

### DIFF
--- a/worker/discovery/commonPaths.ts
+++ b/worker/discovery/commonPaths.ts
@@ -9,7 +9,8 @@ import { validateTargetUrl } from "../validation/url";
 export function tryCommonPaths(
   baseUrl: string,
 ): ResultAsync<FeedResult[], FeedDiscoveryError> {
-  const commonPaths = [
+  // Root level paths (absolute from domain root)
+  const rootPaths = [
     "/feed",
     "/feeds",
     "/rss",
@@ -18,6 +19,19 @@ export function tryCommonPaths(
     "/atom.xml",
     "/index.xml",
   ];
+
+  // Relative paths from current URL path (Issue #35)
+  const relativePaths = [
+    "feed/",
+    "feeds/",
+    "rss/",
+    "feed.xml",
+    "rss.xml",
+    "atom.xml",
+    "index.xml",
+  ];
+
+  const commonPaths = [...rootPaths, ...relativePaths];
 
   // Create all feed URLs first and filter valid ones
   const validFeedUrls = commonPaths


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - フィード自動検出を拡張。ドメイン直下の一般的パスに加え、サブパス配下の相対パス（例: feed/, rss/, atom.xml など）も対象化。RSS/Atom の判定は従来通りで、発見率と精度を向上。
- テスト
  - 相対パス配下のフィード検出を検証するケースを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->