### PR TITLE
fix: Remove flaky micro-timing assertion in parallel processing test

### DIFF
--- a/worker/index.test.ts
+++ b/worker/index.test.ts
@@ -490,12 +490,9 @@ describe("Performance Optimization Tests", () => {
       });
 
       let requestCount = 0;
-      const requestTimes: number[] = [];
 
       mockFetch.mockImplementation(() => {
         requestCount++;
-        const startTime = performance.now();
-        requestTimes.push(startTime);
         return Promise.resolve(mockResponse);
       });
 
@@ -518,17 +515,8 @@ describe("Performance Optimization Tests", () => {
 
       // Test should verify parallel execution characteristics:
       // 1. Multiple requests were made (common paths)
-      // 2. They executed in parallel (similar timing)
+      // 2. Execution completes within a reasonable parallel processing window
       expect(requestCount).toBeGreaterThan(1);
-
-      // Parallel requests should have similar start times (within 10ms)
-      if (requestTimes.length > 1) {
-        const timeDifferences = requestTimes
-          .slice(1)
-          .map((time, i) => Math.abs(time - requestTimes[i]));
-        const maxTimeDifference = Math.max(...timeDifferences);
-        expect(maxTimeDifference).toBeLessThan(10); // Should be nearly simultaneous
-      }
 
       // Total time should be reasonable for parallel execution
       expect(totalTime).toBeLessThan(1000); // Should complete within 1 second

--- a/worker/index.test.ts
+++ b/worker/index.test.ts
@@ -488,12 +488,34 @@ describe("Performance Optimization Tests", () => {
         status: 200,
         headers: { "content-type": "application/rss+xml" },
       });
+      const mockHtmlResponse = new Response("", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
 
-      let requestCount = 0;
+      let headRequestCount = 0;
+      let inFlightHeadRequests = 0;
+      let maxConcurrentHeadRequests = 0;
+      const resolveHeadRequests: Array<() => void> = [];
 
-      mockFetch.mockImplementation(() => {
-        requestCount++;
-        return Promise.resolve(mockResponse);
+      mockFetch.mockImplementation((_url: string, options?: RequestInit) => {
+        if (!options || options.method !== "HEAD") {
+          return Promise.resolve(mockHtmlResponse);
+        }
+
+        headRequestCount++;
+        inFlightHeadRequests++;
+        maxConcurrentHeadRequests = Math.max(
+          maxConcurrentHeadRequests,
+          inFlightHeadRequests,
+        );
+
+        return new Promise<Response>((resolve) => {
+          resolveHeadRequests.push(() => {
+            inFlightHeadRequests--;
+            resolve(mockResponse.clone());
+          });
+        });
       });
 
       const startTime = performance.now();
@@ -508,17 +530,28 @@ describe("Performance Optimization Tests", () => {
         body: JSON.stringify({ url: baseUrl }),
       });
 
-      await worker.fetch(request);
+      const responsePromise = worker.fetch(request);
 
-      const endTime = performance.now();
-      const totalTime = endTime - startTime;
+      try {
+        await vi.waitFor(() => {
+          expect(headRequestCount).toBeGreaterThan(1);
+          expect(maxConcurrentHeadRequests).toBeGreaterThan(1);
+        });
+      } finally {
+        resolveHeadRequests.forEach((resolve) => resolve());
+      }
+
+      await responsePromise;
 
       // Test should verify parallel execution characteristics:
-      // 1. Multiple requests were made (common paths)
-      // 2. Execution completes within a reasonable parallel processing window
-      expect(requestCount).toBeGreaterThan(1);
+      // 1. Multiple HEAD requests were made (common paths)
+      // 2. More than one HEAD request was in flight at the same time
+      expect(headRequestCount).toBeGreaterThan(1);
+      expect(maxConcurrentHeadRequests).toBeGreaterThan(1);
 
       // Total time should be reasonable for parallel execution
+      const endTime = performance.now();
+      const totalTime = endTime - startTime;
       expect(totalTime).toBeLessThan(1000); // Should complete within 1 second
     });
 


### PR DESCRIPTION
## Summary

Removes the flaky micro-timing assertion from `worker/index.test.ts` and replaces it with a deterministic concurrency check for common-path HEAD requests.

## Failure Evidence

- Failed run checked: https://github.com/takuan-osho/feed-finder/actions/runs/25092558683
- Failed test: `worker/index.test.ts > Performance Optimization Tests > Parallel Processing Tests > should execute common paths discovery in parallel (faster than sequential)`
- Failure message: `AssertionError: expected 14.226081000000022 to be less than 10`
- Failure location: `worker/index.test.ts:530`

At least one checked SHA showed different outcomes across reruns:

| SHA | run id | result |
| --- | --- | --- |
| `c51db3570d15a050e8e6b015fa4f466c1c7b5829` | `25092558683` | failure |
| `c51db3570d15a050e8e6b015fa4f466c1c7b5829` | `25092559227` | success |

Additional supplied reruns for another SHA currently resolve as successful in GitHub's API:

| SHA | run id | result |
| --- | --- | --- |
| `3b2dc3b057a15a23b38e67169d3cc7bfc840ca4f` | `25092582376` | success |
| `3b2dc3b057a15a23b38e67169d3cc7bfc840ca4f` | `25092582059` | success |

Note: the originally supplied failed run URL for `25092582376/job/73521832137` did not match the currently visible GitHub API data; `25092582376` currently resolves as successful. The confirmed failure above is from `25092558683`.

## Root Cause

The removed assertion measured the gap between consecutive `mockFetch` implementation calls and required that gap to stay below 10ms. That is a micro-timing property of JavaScript scheduling and runner load, not a reliable proof of parallel behavior. Even when the worker starts work through `Promise.all`, mock callbacks still run through the event loop and can exceed 10ms under GitHub Actions load or GC pauses.

## What Changed

- Removed `requestTimes` collection and the `maxTimeDifference < 10` assertion.
- Changed the test to keep common-path HEAD requests pending and assert that more than one HEAD request is in flight at the same time.
- Kept `expect(totalTime).toBeLessThan(1000)` as a broad completion guard.

## Validation

- `npm ci`
- `npm run lint`
- `npm run test:run` passed 5 consecutive local runs before the Copilot follow-up.
- After adding the deterministic in-flight concurrency assertion:
  - `npm run lint`
  - `npm run test:run -- worker/index.test.ts`
  - `npm run test:run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト

* **テスト**
  * ワーカーのパフォーマンステストを改善し、HTTP リクエストの並行処理計測精度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->