### PR TITLE
Configure Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
       day: "saturday"
       time: "07:00"
       timezone: "Asia/Tokyo"
-      groups:
-        all-actions:
-          patterns: [ "*" ]
+    groups:
+      all-actions:
+        patterns: [ "*" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
+      groups:
+        all-actions:
+          patterns: [ "*" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/" # Location of package manifests
+    directory: "/" # Location of GitHub Actions workflow files
     schedule:
       interval: "weekly"
       day: "saturday"


### PR DESCRIPTION
Add GitHub Actions to Dependabot configuration with schedule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions の自動更新設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->