### PR TITLE
feat: Add light/dark theme toggle and refresh design

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,13 +72,20 @@
       }
       /* Loading state */
       .loading-skeleton {
-        background: linear-gradient(90deg, #223649 25%, #2a3f5a 50%, #223649 75%);
+        background: linear-gradient(90deg, #e2e8f0 25%, #f1f5f9 50%, #e2e8f0 75%);
         background-size: 200% 100%;
         animation: loading 1.5s infinite;
+      }
+      :root[data-theme="dark"] .loading-skeleton {
+        background: linear-gradient(90deg, #223649 25%, #2a3f5a 50%, #223649 75%);
+        background-size: 200% 100%;
       }
       @keyframes loading {
         0% { background-position: 200% 0; }
         100% { background-position: -200% 0; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .loading-skeleton { animation: none; }
       }
     </style>
   </head>

--- a/index.html
+++ b/index.html
@@ -11,19 +11,61 @@
 
     <!-- Meta tags for performance and SEO -->
     <meta name="description" content="RSS / Atom Feed Discovery - Enter a website URL to automatically discover its RSS and Atom feeds">
-    <meta name="theme-color" content="#101a23">
+    <meta name="theme-color" content="#f8fafc">
 
     <!-- Preload critical resources -->
     <link rel="modulepreload" href="/src/main.tsx">
 
+    <script>
+      (() => {
+        const storageKey = "feed-finder-theme";
+        const lightThemeColor = "#f8fafc";
+        const darkThemeColor = "#0b1118";
+
+        try {
+          const storedTheme = localStorage.getItem(storageKey);
+          const prefersDark = window.matchMedia(
+            "(prefers-color-scheme: dark)",
+          ).matches;
+          const theme =
+            storedTheme === "light" || storedTheme === "dark"
+              ? storedTheme
+              : prefersDark
+                ? "dark"
+                : "light";
+
+          document.documentElement.dataset.theme = theme;
+          document.documentElement.classList.toggle("dark", theme === "dark");
+          document.documentElement.style.colorScheme = theme;
+          document
+            .querySelector('meta[name="theme-color"]')
+            ?.setAttribute(
+              "content",
+              theme === "dark" ? darkThemeColor : lightThemeColor,
+            );
+        } catch {
+          document.documentElement.dataset.theme = "light";
+          document.documentElement.style.colorScheme = "light";
+        }
+      })();
+    </script>
+
     <!-- Optimize rendering -->
     <style>
       /* Critical CSS for initial paint */
+      :root {
+        --app-bg: #f8fafc;
+        --app-text: #020617;
+      }
+      :root[data-theme="dark"] {
+        --app-bg: #0b1118;
+        --app-text: #ffffff;
+      }
       body {
         margin: 0;
         font-family: system-ui, -apple-system, sans-serif;
-        background-color: #101a23;
-        color: white;
+        background-color: var(--app-bg);
+        color: var(--app-text);
       }
       #root {
         min-height: 100vh;

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,7 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { THEME_STORAGE_KEY } from "@/lib/theme";
+import { THEME_COLORS, THEME_STORAGE_KEY } from "@/lib/theme";
 import App from "./App";
 
 function mockColorSchemePreference(prefersDark: boolean) {
@@ -25,6 +25,17 @@ function mockColorSchemePreference(prefersDark: boolean) {
   });
 }
 
+function ensureMetaThemeColor(initialContent = "#ffffff") {
+  document
+    .querySelectorAll('meta[name="theme-color"]')
+    .forEach((node) => node.remove());
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", "theme-color");
+  meta.setAttribute("content", initialContent);
+  document.head.appendChild(meta);
+  return meta;
+}
+
 // Bundle Optimization Tests (t-wada style TDD)
 describe("Bundle Optimization Tests", () => {
   beforeEach(() => {
@@ -32,6 +43,9 @@ describe("Bundle Optimization Tests", () => {
     document.documentElement.classList.remove("dark");
     document.documentElement.removeAttribute("data-theme");
     document.documentElement.style.colorScheme = "";
+    document
+      .querySelectorAll('meta[name="theme-color"]')
+      .forEach((node) => node.remove());
     mockColorSchemePreference(false);
   });
 
@@ -41,6 +55,9 @@ describe("Bundle Optimization Tests", () => {
     document.documentElement.classList.remove("dark");
     document.documentElement.removeAttribute("data-theme");
     document.documentElement.style.colorScheme = "";
+    document
+      .querySelectorAll('meta[name="theme-color"]')
+      .forEach((node) => node.remove());
     vi.restoreAllMocks();
   });
 
@@ -134,6 +151,26 @@ describe("Bundle Optimization Tests", () => {
       });
       expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
       expect(themeToggle).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("should sync meta[name=theme-color] when toggling theme", async () => {
+      ensureMetaThemeColor(THEME_COLORS.light);
+
+      render(<App />);
+
+      await waitFor(() => {
+        const meta = document.querySelector('meta[name="theme-color"]');
+        expect(meta?.getAttribute("content")).toBe(THEME_COLORS.light);
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Switch to dark mode" }),
+      );
+
+      await waitFor(() => {
+        const meta = document.querySelector('meta[name="theme-color"]');
+        expect(meta?.getAttribute("content")).toBe(THEME_COLORS.dark);
+      });
     });
   });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { THEME_STORAGE_KEY } from "@/lib/theme";
 import App from "./App";
 
 function mockColorSchemePreference(prefersDark: boolean) {
@@ -29,6 +30,7 @@ describe("Bundle Optimization Tests", () => {
   beforeEach(() => {
     window.localStorage.clear();
     document.documentElement.classList.remove("dark");
+    document.documentElement.removeAttribute("data-theme");
     document.documentElement.style.colorScheme = "";
     mockColorSchemePreference(false);
   });
@@ -37,6 +39,7 @@ describe("Bundle Optimization Tests", () => {
     cleanup();
     window.localStorage.clear();
     document.documentElement.classList.remove("dark");
+    document.documentElement.removeAttribute("data-theme");
     document.documentElement.style.colorScheme = "";
     vi.restoreAllMocks();
   });
@@ -64,7 +67,7 @@ describe("Bundle Optimization Tests", () => {
       render(<App />);
 
       // Check if critical CSS classes are applied to elements
-      const appElement = document.querySelector(".bg-slate-50");
+      const appElement = document.querySelector(".app-shell");
       const minHeightElement = document.querySelector(".min-h-screen");
 
       // At least one critical CSS class should be present
@@ -103,12 +106,12 @@ describe("Bundle Optimization Tests", () => {
       await waitFor(() => {
         expect(document.documentElement).toHaveClass("dark");
       });
-      expect(window.localStorage.getItem("feed-finder-theme")).toBe("dark");
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
     });
 
     it("should prefer saved theme over system preference", async () => {
       mockColorSchemePreference(true);
-      window.localStorage.setItem("feed-finder-theme", "light");
+      window.localStorage.setItem(THEME_STORAGE_KEY, "light");
 
       render(<App />);
 
@@ -129,7 +132,7 @@ describe("Bundle Optimization Tests", () => {
       await waitFor(() => {
         expect(document.documentElement).toHaveClass("dark");
       });
-      expect(window.localStorage.getItem("feed-finder-theme")).toBe("dark");
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
       expect(themeToggle).toHaveAttribute("aria-pressed", "true");
     });
   });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,46 @@
-import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
+
+function mockColorSchemePreference(prefersDark: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(prefers-color-scheme: dark)" && prefersDark,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 // Bundle Optimization Tests (t-wada style TDD)
 describe("Bundle Optimization Tests", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    document.documentElement.style.colorScheme = "";
+    mockColorSchemePreference(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    document.documentElement.style.colorScheme = "";
+    vi.restoreAllMocks();
+  });
+
   describe("Code Splitting Verification", () => {
     it("should lazy load ResultDisplay component to reduce initial bundle", async () => {
       // Green Phase: Adapt test for test environment
@@ -17,9 +54,7 @@ describe("Bundle Optimization Tests", () => {
 
       // Suspense fallback is present in test environment but hidden via Suspense
       // This test validates that the lazy loading structure is in place
-      const suspenseFallback = document.querySelector(
-        ".text-center.text-\\[\\#90aecb\\]",
-      );
+      const suspenseFallback = document.querySelector('[role="status"]');
       // In test environment, Suspense fallback might be visible
       expect(suspenseFallback).not.toBeNull();
     });
@@ -29,7 +64,7 @@ describe("Bundle Optimization Tests", () => {
       render(<App />);
 
       // Check if critical CSS classes are applied to elements
-      const appElement = document.querySelector(".bg-\\[\\#101a23\\]");
+      const appElement = document.querySelector(".bg-slate-50");
       const minHeightElement = document.querySelector(".min-h-screen");
 
       // At least one critical CSS class should be present
@@ -56,6 +91,46 @@ describe("Bundle Optimization Tests", () => {
       render(<App />);
       const title = document.querySelector("h1");
       expect(title?.textContent).toContain("RSS / Atom Feed Discovery");
+    });
+  });
+
+  describe("Theme Toggle Verification", () => {
+    it("should use system dark preference when no theme is saved", async () => {
+      mockColorSchemePreference(true);
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(document.documentElement).toHaveClass("dark");
+      });
+      expect(window.localStorage.getItem("feed-finder-theme")).toBe("dark");
+    });
+
+    it("should prefer saved theme over system preference", async () => {
+      mockColorSchemePreference(true);
+      window.localStorage.setItem("feed-finder-theme", "light");
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(document.documentElement).not.toHaveClass("dark");
+      });
+      expect(document.documentElement.style.colorScheme).toBe("light");
+    });
+
+    it("should toggle theme and persist the user choice", async () => {
+      render(<App />);
+
+      const themeToggle = screen.getByRole("button", {
+        name: "Switch to dark mode",
+      });
+      fireEvent.click(themeToggle);
+
+      await waitFor(() => {
+        expect(document.documentElement).toHaveClass("dark");
+      });
+      expect(window.localStorage.getItem("feed-finder-theme")).toBe("dark");
+      expect(themeToggle).toHaveAttribute("aria-pressed", "true");
     });
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import { Moon, Rss, Sun } from "lucide-react";
-import { type CSSProperties, lazy, Suspense, useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { SearchForm } from "@/components/SearchForm";
 import { Button } from "@/components/ui/button";
 import { parseApiError, parseSearchResult } from "@/lib/schemas";
+import { THEME_STORAGE_KEY } from "@/lib/theme";
 import type { SearchResult } from "../shared/types";
 
 // Lazy load the ResultDisplay component to reduce initial bundle size
@@ -14,67 +15,6 @@ const ResultDisplay = lazy(() =>
 
 type Theme = "light" | "dark";
 
-const THEME_STORAGE_KEY = "feed-finder-theme";
-
-const themeVariables: Record<Theme, Record<string, string>> = {
-  light: {
-    "--app-bg": "#f8fafc",
-    "--app-text": "#020617",
-    "--app-muted": "#475569",
-    "--app-placeholder": "#94a3b8",
-    "--app-border": "rgb(226 232 240 / 0.85)",
-    "--app-header-bg": "rgb(255 255 255 / 0.82)",
-    "--app-surface": "rgb(255 255 255 / 0.92)",
-    "--app-surface-solid": "#ffffff",
-    "--app-control-bg": "rgb(255 255 255 / 0.92)",
-    "--app-control-hover": "#f1f5f9",
-    "--app-input-bg": "rgb(248 250 252 / 0.85)",
-    "--app-input-border": "#e2e8f0",
-    "--app-input-shadow": "rgb(226 232 240 / 0.6)",
-    "--app-code-bg": "#f8fafc",
-    "--app-card-shadow": "rgb(226 232 240 / 0.6)",
-    "--app-button-bg": "#0d9488",
-    "--app-button-hover": "#0f766e",
-    "--app-button-text": "#ffffff",
-    "--app-button-shadow": "rgb(13 148 136 / 0.2)",
-    "--app-accent": "#0f766e",
-    "--app-accent-soft": "#f0fdfa",
-    "--app-accent-border": "#99f6e4",
-    "--app-focus": "#14b8a6",
-    "--app-focus-soft": "rgb(20 184 166 / 0.2)",
-    "--app-hero-glow":
-      "radial-gradient(circle at 50% 0%, rgb(20 184 166 / 0.18), transparent 58%)",
-  },
-  dark: {
-    "--app-bg": "#0b1118",
-    "--app-text": "#ffffff",
-    "--app-muted": "#cbd5e1",
-    "--app-placeholder": "#64748b",
-    "--app-border": "rgb(255 255 255 / 0.1)",
-    "--app-header-bg": "rgb(11 17 24 / 0.82)",
-    "--app-surface": "rgb(255 255 255 / 0.06)",
-    "--app-surface-solid": "#111c27",
-    "--app-control-bg": "rgb(255 255 255 / 0.05)",
-    "--app-control-hover": "rgb(255 255 255 / 0.1)",
-    "--app-input-bg": "#0d1823",
-    "--app-input-border": "rgb(255 255 255 / 0.1)",
-    "--app-input-shadow": "transparent",
-    "--app-code-bg": "#0b1118",
-    "--app-card-shadow": "rgb(0 0 0 / 0.2)",
-    "--app-button-bg": "#0ea5e9",
-    "--app-button-hover": "#38bdf8",
-    "--app-button-text": "#020617",
-    "--app-button-shadow": "rgb(14 165 233 / 0.2)",
-    "--app-accent": "#7dd3fc",
-    "--app-accent-soft": "rgb(56 189 248 / 0.1)",
-    "--app-accent-border": "rgb(56 189 248 / 0.35)",
-    "--app-focus": "#38bdf8",
-    "--app-focus-soft": "rgb(56 189 248 / 0.2)",
-    "--app-hero-glow":
-      "radial-gradient(circle at 50% 0%, rgb(56 189 248 / 0.2), transparent 58%)",
-  },
-};
-
 function getInitialTheme(): Theme {
   if (typeof window === "undefined") {
     return "light";
@@ -85,7 +25,11 @@ function getInitialTheme(): Theme {
     return storedTheme;
   }
 
-  return window.matchMedia?.("(prefers-color-scheme: dark)").matches
+  if (typeof window.matchMedia !== "function") {
+    return "light";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
     ? "dark"
     : "light";
 }
@@ -100,11 +44,8 @@ function App() {
     const isDark = theme === "dark";
 
     document.documentElement.classList.toggle("dark", isDark);
-    document.documentElement.dataset.theme = theme;
+    document.documentElement.dataset["theme"] = theme;
     document.documentElement.style.colorScheme = theme;
-    for (const [name, value] of Object.entries(themeVariables[theme])) {
-      document.documentElement.style.setProperty(name, value);
-    }
     window.localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
@@ -141,37 +82,12 @@ function App() {
   };
 
   return (
-    <div
-      className="app-shell relative flex min-h-screen flex-col overflow-hidden transition-colors duration-300"
-      style={
-        {
-          ...themeVariables[theme],
-          backgroundColor: "var(--app-bg)",
-          color: "var(--app-text)",
-        } as CSSProperties
-      }
-    >
-      <div
-        className="app-hero-glow pointer-events-none absolute inset-x-0 top-0 h-80"
-        style={{ backgroundImage: "var(--app-hero-glow)" }}
-      />
+    <div className="app-shell relative flex min-h-screen flex-col overflow-hidden transition-colors duration-300">
+      <div className="app-hero-glow pointer-events-none absolute inset-x-0 top-0 h-80" />
       <div className="layout-container relative flex h-full grow flex-col">
-        <header
-          className="app-header flex items-center justify-between whitespace-nowrap border-b px-5 py-3 backdrop-blur-xl sm:px-10"
-          style={{
-            backgroundColor: "var(--app-header-bg)",
-            borderColor: "var(--app-border)",
-          }}
-        >
+        <header className="app-header flex items-center justify-between whitespace-nowrap border-b px-5 py-3 backdrop-blur-xl sm:px-10">
           <div className="flex items-center gap-3">
-            <div
-              className="app-accent-box flex size-9 items-center justify-center rounded-lg border shadow-sm"
-              style={{
-                backgroundColor: "var(--app-accent-soft)",
-                borderColor: "var(--app-accent-border)",
-                color: "var(--app-accent)",
-              }}
-            >
+            <div className="app-accent-box flex size-9 items-center justify-center rounded-lg border shadow-sm">
               <Rss className="size-4" aria-hidden="true" />
             </div>
             <h2 className="text-lg font-bold leading-tight tracking-normal">
@@ -183,11 +99,6 @@ function App() {
             variant="outline"
             size="icon"
             className="app-control size-10 rounded-lg border shadow-sm focus:outline-none focus:ring-2"
-            style={{
-              backgroundColor: "var(--app-control-bg)",
-              borderColor: "var(--app-border)",
-              color: "var(--app-muted)",
-            }}
             aria-label={
               theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
             }
@@ -208,19 +119,13 @@ function App() {
         <main className="flex flex-1 justify-center px-5 py-10 sm:px-10 lg:px-40">
           <div className="layout-content-container flex max-w-[960px] flex-1 flex-col space-y-8">
             <section className="mx-auto max-w-3xl text-center">
-              <p
-                className="app-accent-text mb-3 text-sm font-medium"
-                style={{ color: "var(--app-accent)" }}
-              >
+              <p className="app-accent-text mb-3 text-sm font-medium">
                 Discover publishable feeds faster
               </p>
               <h1 className="text-balance text-4xl font-bold leading-tight tracking-normal sm:text-5xl">
                 RSS / Atom Feed Discovery
               </h1>
-              <p
-                className="app-muted mx-auto mt-4 max-w-2xl text-base leading-7"
-                style={{ color: "var(--app-muted)" }}
-              >
+              <p className="app-muted mx-auto mt-4 max-w-2xl text-base leading-7">
                 Enter a website URL to automatically discover its RSS and Atom
                 feeds
               </p>
@@ -238,7 +143,6 @@ function App() {
               fallback={
                 <div
                   className="app-muted text-center"
-                  style={{ color: "var(--app-muted)" }}
                   role="status"
                   aria-live="polite"
                 >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { lazy, Suspense, useEffect, useState } from "react";
 import { SearchForm } from "@/components/SearchForm";
 import { Button } from "@/components/ui/button";
 import { parseApiError, parseSearchResult } from "@/lib/schemas";
-import { THEME_STORAGE_KEY } from "@/lib/theme";
+import { applyTheme, getInitialTheme, type Theme } from "@/lib/theme";
 import type { SearchResult } from "../shared/types";
 
 // Lazy load the ResultDisplay component to reduce initial bundle size
@@ -13,27 +13,6 @@ const ResultDisplay = lazy(() =>
   })),
 );
 
-type Theme = "light" | "dark";
-
-function getInitialTheme(): Theme {
-  if (typeof window === "undefined") {
-    return "light";
-  }
-
-  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
-  if (storedTheme === "light" || storedTheme === "dark") {
-    return storedTheme;
-  }
-
-  if (typeof window.matchMedia !== "function") {
-    return "light";
-  }
-
-  return window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light";
-}
-
 function App() {
   const [searchResult, setSearchResult] = useState<SearchResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -41,12 +20,7 @@ function App() {
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
 
   useEffect(() => {
-    const isDark = theme === "dark";
-
-    document.documentElement.classList.toggle("dark", isDark);
-    document.documentElement.dataset["theme"] = theme;
-    document.documentElement.style.colorScheme = theme;
-    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    applyTheme(theme);
   }, [theme]);
 
   const handleSearch = async (url: string) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
-import { lazy, Suspense, useState } from "react";
+import { Moon, Rss, Sun } from "lucide-react";
+import { type CSSProperties, lazy, Suspense, useEffect, useState } from "react";
 import { SearchForm } from "@/components/SearchForm";
+import { Button } from "@/components/ui/button";
 import { parseApiError, parseSearchResult } from "@/lib/schemas";
 import type { SearchResult } from "../shared/types";
 
@@ -10,10 +12,101 @@ const ResultDisplay = lazy(() =>
   })),
 );
 
+type Theme = "light" | "dark";
+
+const THEME_STORAGE_KEY = "feed-finder-theme";
+
+const themeVariables: Record<Theme, Record<string, string>> = {
+  light: {
+    "--app-bg": "#f8fafc",
+    "--app-text": "#020617",
+    "--app-muted": "#475569",
+    "--app-placeholder": "#94a3b8",
+    "--app-border": "rgb(226 232 240 / 0.85)",
+    "--app-header-bg": "rgb(255 255 255 / 0.82)",
+    "--app-surface": "rgb(255 255 255 / 0.92)",
+    "--app-surface-solid": "#ffffff",
+    "--app-control-bg": "rgb(255 255 255 / 0.92)",
+    "--app-control-hover": "#f1f5f9",
+    "--app-input-bg": "rgb(248 250 252 / 0.85)",
+    "--app-input-border": "#e2e8f0",
+    "--app-input-shadow": "rgb(226 232 240 / 0.6)",
+    "--app-code-bg": "#f8fafc",
+    "--app-card-shadow": "rgb(226 232 240 / 0.6)",
+    "--app-button-bg": "#0d9488",
+    "--app-button-hover": "#0f766e",
+    "--app-button-text": "#ffffff",
+    "--app-button-shadow": "rgb(13 148 136 / 0.2)",
+    "--app-accent": "#0f766e",
+    "--app-accent-soft": "#f0fdfa",
+    "--app-accent-border": "#99f6e4",
+    "--app-focus": "#14b8a6",
+    "--app-focus-soft": "rgb(20 184 166 / 0.2)",
+    "--app-hero-glow":
+      "radial-gradient(circle at 50% 0%, rgb(20 184 166 / 0.18), transparent 58%)",
+  },
+  dark: {
+    "--app-bg": "#0b1118",
+    "--app-text": "#ffffff",
+    "--app-muted": "#cbd5e1",
+    "--app-placeholder": "#64748b",
+    "--app-border": "rgb(255 255 255 / 0.1)",
+    "--app-header-bg": "rgb(11 17 24 / 0.82)",
+    "--app-surface": "rgb(255 255 255 / 0.06)",
+    "--app-surface-solid": "#111c27",
+    "--app-control-bg": "rgb(255 255 255 / 0.05)",
+    "--app-control-hover": "rgb(255 255 255 / 0.1)",
+    "--app-input-bg": "#0d1823",
+    "--app-input-border": "rgb(255 255 255 / 0.1)",
+    "--app-input-shadow": "transparent",
+    "--app-code-bg": "#0b1118",
+    "--app-card-shadow": "rgb(0 0 0 / 0.2)",
+    "--app-button-bg": "#0ea5e9",
+    "--app-button-hover": "#38bdf8",
+    "--app-button-text": "#020617",
+    "--app-button-shadow": "rgb(14 165 233 / 0.2)",
+    "--app-accent": "#7dd3fc",
+    "--app-accent-soft": "rgb(56 189 248 / 0.1)",
+    "--app-accent-border": "rgb(56 189 248 / 0.35)",
+    "--app-focus": "#38bdf8",
+    "--app-focus-soft": "rgb(56 189 248 / 0.2)",
+    "--app-hero-glow":
+      "radial-gradient(circle at 50% 0%, rgb(56 189 248 / 0.2), transparent 58%)",
+  },
+};
+
+function getInitialTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (storedTheme === "light" || storedTheme === "dark") {
+    return storedTheme;
+  }
+
+  return window.matchMedia?.("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
 function App() {
   const [searchResult, setSearchResult] = useState<SearchResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    const isDark = theme === "dark";
+
+    document.documentElement.classList.toggle("dark", isDark);
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+    for (const [name, value] of Object.entries(themeVariables[theme])) {
+      document.documentElement.style.setProperty(name, value);
+    }
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
 
   const handleSearch = async (url: string) => {
     setIsLoading(true);
@@ -48,34 +141,86 @@ function App() {
   };
 
   return (
-    <div className="relative flex min-h-screen flex-col bg-[#101a23] text-white">
-      <div className="layout-container flex h-full grow flex-col">
-        <header className="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#223649] px-10 py-3">
-          <div className="flex items-center gap-4 text-white">
-            <div className="size-4">
-              <svg
-                viewBox="0 0 48 48"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M24 4C25.7818 14.2173 33.7827 22.2182 44 24C33.7827 25.7818 25.7818 33.7827 24 44C22.2182 33.7827 14.2173 25.7818 4 24C14.2173 22.2182 22.2182 14.2173 24 4Z"
-                  fill="currentColor"
-                ></path>
-              </svg>
+    <div
+      className="app-shell relative flex min-h-screen flex-col overflow-hidden transition-colors duration-300"
+      style={
+        {
+          ...themeVariables[theme],
+          backgroundColor: "var(--app-bg)",
+          color: "var(--app-text)",
+        } as CSSProperties
+      }
+    >
+      <div
+        className="app-hero-glow pointer-events-none absolute inset-x-0 top-0 h-80"
+        style={{ backgroundImage: "var(--app-hero-glow)" }}
+      />
+      <div className="layout-container relative flex h-full grow flex-col">
+        <header
+          className="app-header flex items-center justify-between whitespace-nowrap border-b px-5 py-3 backdrop-blur-xl sm:px-10"
+          style={{
+            backgroundColor: "var(--app-header-bg)",
+            borderColor: "var(--app-border)",
+          }}
+        >
+          <div className="flex items-center gap-3">
+            <div
+              className="app-accent-box flex size-9 items-center justify-center rounded-lg border shadow-sm"
+              style={{
+                backgroundColor: "var(--app-accent-soft)",
+                borderColor: "var(--app-accent-border)",
+                color: "var(--app-accent)",
+              }}
+            >
+              <Rss className="size-4" aria-hidden="true" />
             </div>
-            <h2 className="text-white text-lg font-bold leading-tight tracking-[-0.015em]">
+            <h2 className="text-lg font-bold leading-tight tracking-normal">
               FeedFinder
             </h2>
           </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="app-control size-10 rounded-lg border shadow-sm focus:outline-none focus:ring-2"
+            style={{
+              backgroundColor: "var(--app-control-bg)",
+              borderColor: "var(--app-border)",
+              color: "var(--app-muted)",
+            }}
+            aria-label={
+              theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
+            }
+            aria-pressed={theme === "dark"}
+            onClick={() =>
+              setTheme((currentTheme) =>
+                currentTheme === "dark" ? "light" : "dark",
+              )
+            }
+          >
+            {theme === "dark" ? (
+              <Sun className="size-4" aria-hidden="true" />
+            ) : (
+              <Moon className="size-4" aria-hidden="true" />
+            )}
+          </Button>
         </header>
-        <main className="px-10 lg:px-40 flex flex-1 justify-center py-8">
-          <div className="layout-content-container flex flex-col max-w-[960px] flex-1 space-y-8">
-            <section className="text-center">
-              <h1 className="text-white tracking-light text-[28px] font-bold leading-tight">
+        <main className="flex flex-1 justify-center px-5 py-10 sm:px-10 lg:px-40">
+          <div className="layout-content-container flex max-w-[960px] flex-1 flex-col space-y-8">
+            <section className="mx-auto max-w-3xl text-center">
+              <p
+                className="app-accent-text mb-3 text-sm font-medium"
+                style={{ color: "var(--app-accent)" }}
+              >
+                Discover publishable feeds faster
+              </p>
+              <h1 className="text-balance text-4xl font-bold leading-tight tracking-normal sm:text-5xl">
                 RSS / Atom Feed Discovery
               </h1>
-              <p className="text-[#90aecb] mt-2 text-base">
+              <p
+                className="app-muted mx-auto mt-4 max-w-2xl text-base leading-7"
+                style={{ color: "var(--app-muted)" }}
+              >
                 Enter a website URL to automatically discover its RSS and Atom
                 feeds
               </p>
@@ -92,7 +237,8 @@ function App() {
             <Suspense
               fallback={
                 <div
-                  className="text-center text-[#90aecb]"
+                  className="app-muted text-center"
+                  style={{ color: "var(--app-muted)" }}
                   role="status"
                   aria-live="polite"
                 >

--- a/src/components/ResultDisplay.test.tsx
+++ b/src/components/ResultDisplay.test.tsx
@@ -30,8 +30,8 @@ describe("ResultDisplay", () => {
       render(<ResultDisplay result={null} error="Test error" />);
 
       const alert = screen.getByRole("alert");
-      expect(alert.className).toContain("bg-red-950");
-      expect(alert.className).toContain("border-red-800");
+      expect(alert.className).toContain("bg-red-50");
+      expect(alert.className).toContain("border-red-200");
     });
   });
 
@@ -128,8 +128,8 @@ describe("ResultDisplay", () => {
       const rssBadge = screen.getByText("RSS");
       const atomBadge = screen.getByText("Atom");
 
-      expect(rssBadge.className).toContain("bg-orange-900");
-      expect(atomBadge.className).toContain("bg-blue-900");
+      expect(rssBadge.className).toContain("bg-orange-100");
+      expect(atomBadge.className).toContain("bg-blue-100");
     });
 
     it("should display discovery method correctly", () => {
@@ -298,7 +298,7 @@ describe("ResultDisplay", () => {
         expect(screen.getByText("Copied")).toBeInTheDocument();
       });
 
-      expect(copyButton.className).toContain("bg-green-900");
+      expect(copyButton.className).toContain("bg-emerald-100");
 
       vi.advanceTimersByTime(2000);
 

--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -52,11 +52,6 @@ export function ResultDisplay({ result, error }: ResultDisplayProps) {
     return (
       <Alert
         className="app-surface app-muted mx-auto max-w-3xl border shadow-lg"
-        style={{
-          backgroundColor: "var(--app-surface)",
-          borderColor: "var(--app-border)",
-          color: "var(--app-muted)",
-        }}
         role="status"
         aria-live="polite"
       >
@@ -133,12 +128,6 @@ function FeedCard({ feed, onCopyUrl, onOpenFeed, copiedUrl }: FeedCardProps) {
   return (
     <article
       className="app-surface rounded-lg border shadow-lg transition-colors duration-200 hover:border-[var(--app-accent-border)]"
-      style={{
-        backgroundColor: "var(--app-surface)",
-        borderColor: "var(--app-border)",
-        color: "var(--app-text)",
-        boxShadow: "0 10px 24px var(--app-card-shadow)",
-      }}
       aria-labelledby={`feed-title-${feed.url.replace(/[^a-zA-Z0-9]/g, "-")}`}
     >
       <header className="p-6 pb-3">
@@ -146,8 +135,7 @@ function FeedCard({ feed, onCopyUrl, onOpenFeed, copiedUrl }: FeedCardProps) {
           <div className="flex-1 min-w-0">
             <h3
               id={`feed-title-${feed.url.replace(/[^a-zA-Z0-9]/g, "-")}`}
-              className="truncate text-lg font-semibold leading-tight"
-              style={{ color: "var(--app-text)" }}
+              className="app-text truncate text-lg font-semibold leading-tight"
             >
               {feed.title || feed.url}
             </h3>
@@ -164,7 +152,6 @@ function FeedCard({ feed, onCopyUrl, onOpenFeed, copiedUrl }: FeedCardProps) {
               </span>
               <span
                 className="app-muted text-xs"
-                style={{ color: "var(--app-muted)" }}
                 aria-label={`Discovery method: ${discoveryMethodText}`}
               >
                 {discoveryMethodText}
@@ -176,28 +163,14 @@ function FeedCard({ feed, onCopyUrl, onOpenFeed, copiedUrl }: FeedCardProps) {
 
       <div className="px-6 pb-6">
         {feed.description && (
-          <p
-            className="app-muted mb-3 line-clamp-2 text-sm leading-6"
-            style={{ color: "var(--app-muted)" }}
-          >
+          <p className="app-muted mb-3 line-clamp-2 text-sm leading-6">
             {feed.description}
           </p>
         )}
 
         <div className="space-y-2">
-          <div
-            className="app-code-block rounded border p-3"
-            style={{
-              backgroundColor: "var(--app-code-bg)",
-              borderColor: "var(--app-input-border)",
-            }}
-          >
-            <code
-              className="app-muted break-all text-xs"
-              style={{ color: "var(--app-muted)" }}
-            >
-              {feed.url}
-            </code>
+          <div className="app-code-block rounded border p-3">
+            <code className="app-muted break-all text-xs">{feed.url}</code>
           </div>
 
           <div
@@ -210,11 +183,6 @@ function FeedCard({ feed, onCopyUrl, onOpenFeed, copiedUrl }: FeedCardProps) {
               variant="outline"
               size="sm"
               className="app-control border focus:outline-none focus:ring-2 focus:ring-offset-2"
-              style={{
-                backgroundColor: "var(--app-control-bg)",
-                borderColor: "var(--app-border)",
-                color: "var(--app-muted)",
-              }}
               aria-label={`Open the feed for ${feed.title || feed.url} in a new tab`}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
@@ -236,15 +204,6 @@ function FeedCard({ feed, onCopyUrl, onOpenFeed, copiedUrl }: FeedCardProps) {
                   ? "border-emerald-200 bg-emerald-100 text-emerald-900 hover:bg-emerald-200 dark:border-emerald-500/30 dark:bg-emerald-900/60 dark:text-emerald-100 dark:hover:bg-emerald-800/70"
                   : "app-control border"
               }`}
-              style={
-                isUrlCopied
-                  ? undefined
-                  : {
-                      backgroundColor: "var(--app-control-bg)",
-                      borderColor: "var(--app-border)",
-                      color: "var(--app-muted)",
-                    }
-              }
               aria-label={`Copy the URL of ${feed.title || feed.url} to the clipboard`}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {

--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -32,12 +32,12 @@ export function ResultDisplay({ result, error }: ResultDisplayProps) {
     return (
       <Alert
         variant="destructive"
-        className="bg-red-950 border-red-800 max-w-2xl mx-auto"
+        className="mx-auto max-w-3xl border-red-200 bg-red-50 text-red-900 dark:border-red-500/30 dark:bg-red-950/40 dark:text-red-100"
         role="alert"
         aria-live="assertive"
       >
         <XCircle className="h-4 w-4" aria-hidden="true" />
-        <AlertDescription className="text-red-200">
+        <AlertDescription className="text-red-800 dark:text-red-100">
           <strong>An error occurred:</strong> {error}
         </AlertDescription>
       </Alert>
@@ -51,12 +51,17 @@ export function ResultDisplay({ result, error }: ResultDisplayProps) {
   if (!result.success || result.feeds.length === 0) {
     return (
       <Alert
-        className="bg-[#182734] border-[#314d68] max-w-2xl mx-auto"
+        className="app-surface app-muted mx-auto max-w-3xl border shadow-lg"
+        style={{
+          backgroundColor: "var(--app-surface)",
+          borderColor: "var(--app-border)",
+          color: "var(--app-muted)",
+        }}
         role="status"
         aria-live="polite"
       >
-        <Info className="h-4 w-4 text-[#90aecb]" aria-hidden="true" />
-        <AlertDescription className="text-[#90aecb]">
+        <Info className="app-accent-text h-4 w-4" aria-hidden="true" />
+        <AlertDescription className="app-muted">
           <strong>No feeds were found</strong>
           <br />
           Could not discover any RSS / Atom feeds for {result.searchedUrl}.
@@ -73,18 +78,21 @@ export function ResultDisplay({ result, error }: ResultDisplayProps) {
 
   return (
     <section
-      className="w-full max-w-2xl mx-auto space-y-4"
+      className="mx-auto w-full max-w-3xl space-y-4"
       data-testid="result-display"
       aria-label="Search results"
     >
       <header>
         <Alert
-          className="bg-green-950 border-green-800"
+          className="border-emerald-200 bg-emerald-50 text-emerald-950 shadow-lg shadow-emerald-100/60 dark:border-emerald-400/25 dark:bg-emerald-950/35 dark:text-emerald-100 dark:shadow-black/20"
           role="status"
           aria-live="polite"
         >
-          <CheckCircle className="h-4 w-4 text-green-400" aria-hidden="true" />
-          <AlertDescription className="text-green-200">
+          <CheckCircle
+            className="h-4 w-4 text-emerald-600 dark:text-emerald-300"
+            aria-hidden="true"
+          />
+          <AlertDescription className="text-emerald-900 dark:text-emerald-100">
             <strong>Found {result.totalFound} feed(s)</strong>
             <br />
             Searched: {result.searchedUrl}
@@ -124,7 +132,13 @@ function FeedCard({ feed, onCopyUrl, onOpenFeed, copiedUrl }: FeedCardProps) {
 
   return (
     <article
-      className="bg-[#182734] border border-[#314d68] hover:border-[#0b80ee]/50 transition-colors duration-200 rounded-lg"
+      className="app-surface rounded-lg border shadow-lg transition-colors duration-200 hover:border-[var(--app-accent-border)]"
+      style={{
+        backgroundColor: "var(--app-surface)",
+        borderColor: "var(--app-border)",
+        color: "var(--app-text)",
+        boxShadow: "0 10px 24px var(--app-card-shadow)",
+      }}
       aria-labelledby={`feed-title-${feed.url.replace(/[^a-zA-Z0-9]/g, "-")}`}
     >
       <header className="p-6 pb-3">
@@ -132,23 +146,25 @@ function FeedCard({ feed, onCopyUrl, onOpenFeed, copiedUrl }: FeedCardProps) {
           <div className="flex-1 min-w-0">
             <h3
               id={`feed-title-${feed.url.replace(/[^a-zA-Z0-9]/g, "-")}`}
-              className="text-white text-lg leading-tight truncate"
+              className="truncate text-lg font-semibold leading-tight"
+              style={{ color: "var(--app-text)" }}
             >
               {feed.title || feed.url}
             </h3>
-            <div className="flex items-center gap-2 mt-1">
+            <div className="mt-2 flex flex-wrap items-center gap-2">
               <span
-                className={`px-2 py-1 text-xs font-medium rounded ${
+                className={`rounded px-2 py-1 text-xs font-semibold ${
                   feed.type === "RSS"
-                    ? "bg-orange-900 text-orange-200"
-                    : "bg-blue-900 text-blue-200"
+                    ? "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200"
+                    : "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
                 }`}
                 aria-label={`Feed type: ${feed.type}`}
               >
                 {feed.type}
               </span>
               <span
-                className="text-xs text-[#90aecb]"
+                className="app-muted text-xs"
+                style={{ color: "var(--app-muted)" }}
                 aria-label={`Discovery method: ${discoveryMethodText}`}
               >
                 {discoveryMethodText}
@@ -160,22 +176,45 @@ function FeedCard({ feed, onCopyUrl, onOpenFeed, copiedUrl }: FeedCardProps) {
 
       <div className="px-6 pb-6">
         {feed.description && (
-          <p className="text-sm text-[#90aecb] mb-3 line-clamp-2">
+          <p
+            className="app-muted mb-3 line-clamp-2 text-sm leading-6"
+            style={{ color: "var(--app-muted)" }}
+          >
             {feed.description}
           </p>
         )}
 
         <div className="space-y-2">
-          <div className="p-2 bg-[#101a23] rounded border border-[#314d68]">
-            <code className="text-xs text-[#90aecb] break-all">{feed.url}</code>
+          <div
+            className="app-code-block rounded border p-3"
+            style={{
+              backgroundColor: "var(--app-code-bg)",
+              borderColor: "var(--app-input-border)",
+            }}
+          >
+            <code
+              className="app-muted break-all text-xs"
+              style={{ color: "var(--app-muted)" }}
+            >
+              {feed.url}
+            </code>
           </div>
 
-          <div className="flex gap-2" role="group" aria-label="Feed actions">
+          <div
+            className="grid gap-2 sm:grid-cols-2"
+            role="group"
+            aria-label="Feed actions"
+          >
             <Button
               onClick={() => onOpenFeed(feed.url)}
               variant="outline"
               size="sm"
-              className="flex-1 bg-[#182734] border-[#314d68] text-white hover:bg-[#314d68] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#0b80ee] focus:ring-offset-2 focus:ring-offset-[#182734]"
+              className="app-control border focus:outline-none focus:ring-2 focus:ring-offset-2"
+              style={{
+                backgroundColor: "var(--app-control-bg)",
+                borderColor: "var(--app-border)",
+                color: "var(--app-muted)",
+              }}
               aria-label={`Open the feed for ${feed.title || feed.url} in a new tab`}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
@@ -192,11 +231,20 @@ function FeedCard({ feed, onCopyUrl, onOpenFeed, copiedUrl }: FeedCardProps) {
               onClick={() => onCopyUrl(feed.url)}
               variant="outline"
               size="sm"
-              className={`flex-1 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[#0b80ee] focus:ring-offset-2 focus:ring-offset-[#182734] ${
+              className={`transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 ${
                 isUrlCopied
-                  ? "bg-green-900 border-green-700 text-green-200 hover:bg-green-800"
-                  : "bg-[#182734] border-[#314d68] text-white hover:bg-[#314d68] hover:text-white"
+                  ? "border-emerald-200 bg-emerald-100 text-emerald-900 hover:bg-emerald-200 dark:border-emerald-500/30 dark:bg-emerald-900/60 dark:text-emerald-100 dark:hover:bg-emerald-800/70"
+                  : "app-control border"
               }`}
+              style={
+                isUrlCopied
+                  ? undefined
+                  : {
+                      backgroundColor: "var(--app-control-bg)",
+                      borderColor: "var(--app-border)",
+                      color: "var(--app-muted)",
+                    }
+              }
               aria-label={`Copy the URL of ${feed.title || feed.url} to the clipboard`}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -89,15 +89,20 @@ export function SearchForm({
   };
 
   return (
-    <Card className="w-full max-w-2xl mx-auto bg-[#182734] border-[#314d68]">
-      <CardContent className="p-6">
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <fieldset className="space-y-2">
+    <Card
+      className="app-surface mx-auto w-full max-w-3xl border shadow-xl backdrop-blur"
+      style={{
+        backgroundColor: "var(--app-surface)",
+        borderColor: "var(--app-border)",
+        color: "var(--app-text)",
+        boxShadow: "0 24px 48px var(--app-card-shadow)",
+      }}
+    >
+      <CardContent className="p-5 sm:p-7">
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <fieldset className="space-y-2.5">
             <legend className="sr-only">Feed search form</legend>
-            <label
-              htmlFor="url-input"
-              className="block text-sm font-medium text-white"
-            >
+            <label htmlFor="url-input" className="block text-sm font-semibold">
               Website URL
             </label>
             <Input
@@ -108,7 +113,12 @@ export function SearchForm({
               value={url}
               onChange={handleUrlChange}
               disabled={isLoading}
-              className="w-full bg-[#182734] border-[#314d68] text-white placeholder:text-[#90aecb] focus:border-[#0b80ee] focus:ring-1 focus:ring-[#0b80ee] focus:outline-none"
+              className="app-input h-12 w-full rounded-lg border px-4 shadow-inner transition-colors focus:ring-2 focus:outline-none"
+              style={{
+                backgroundColor: "var(--app-input-bg)",
+                borderColor: "var(--app-input-border)",
+                color: "var(--app-text)",
+              }}
               aria-describedby={
                 validationError
                   ? "url-error"
@@ -129,12 +139,15 @@ export function SearchForm({
           {validationError && (
             <Alert
               variant="destructive"
-              className="bg-red-950 border-red-800"
+              className="border-red-200 bg-red-50 text-red-900 dark:border-red-500/30 dark:bg-red-950/40 dark:text-red-100"
               role="alert"
               ref={errorRef}
               tabIndex={-1}
             >
-              <AlertDescription id="url-error" className="text-red-200">
+              <AlertDescription
+                id="url-error"
+                className="text-red-800 dark:text-red-100"
+              >
                 {validationError}
               </AlertDescription>
             </Alert>
@@ -143,10 +156,13 @@ export function SearchForm({
           {error && (
             <Alert
               variant="destructive"
-              className="bg-red-950 border-red-800"
+              className="border-red-200 bg-red-50 text-red-900 dark:border-red-500/30 dark:bg-red-950/40 dark:text-red-100"
               role="alert"
             >
-              <AlertDescription id="submit-error" className="text-red-200">
+              <AlertDescription
+                id="submit-error"
+                className="text-red-800 dark:text-red-100"
+              >
                 {error}
               </AlertDescription>
             </Alert>
@@ -155,7 +171,12 @@ export function SearchForm({
           <Button
             type="submit"
             disabled={isLoading || !url.trim()}
-            className="w-full bg-[#0b80ee] hover:bg-[#0b80ee]/80 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-[#0b80ee] focus:ring-offset-2 focus:ring-offset-[#182734]"
+            className="app-primary-button h-12 w-full rounded-lg px-4 py-2 font-semibold shadow-lg transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
+            style={{
+              backgroundColor: "var(--app-button-bg)",
+              color: "var(--app-button-text)",
+              boxShadow: "0 10px 15px -3px var(--app-button-shadow)",
+            }}
             aria-describedby="url-help"
             aria-label={
               isLoading
@@ -177,8 +198,14 @@ export function SearchForm({
           </Button>
         </form>
 
-        <aside className="mt-4 text-sm text-[#90aecb]">
-          <p id="url-help">
+        <aside
+          className="app-muted mt-5 border-t border-[var(--app-border)] pt-4 text-sm leading-6"
+          style={{
+            borderColor: "var(--app-border)",
+            color: "var(--app-muted)",
+          }}
+        >
+          <p id="url-help" className="max-w-2xl">
             This tool automatically discovers RSS / Atom feeds for the website
             you specify.
           </p>

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { err, ok, Result } from "neverthrow";
+import { err, Result } from "neverthrow";
 import { useEffect, useRef, useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -41,15 +41,13 @@ export function SearchForm({
     const hasProtocol = /^https?:\/\//i.test(trimmed);
     const testUrl = hasProtocol ? trimmed : `https://${trimmed}`;
 
-    try {
-      // Throws on invalid URLs
-      new URL(testUrl);
-      return ok(testUrl);
-    } catch {
-      return err(
+    const safeCreateUrl = Result.fromThrowable(
+      () => new URL(testUrl),
+      () =>
         "Please enter a valid URL (e.g., example.com or https://example.com)",
-      );
-    }
+    );
+
+    return safeCreateUrl().map(() => testUrl);
   };
 
   const validateUrl = (input: string): boolean => {

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -89,15 +89,7 @@ export function SearchForm({
   };
 
   return (
-    <Card
-      className="app-surface mx-auto w-full max-w-3xl border shadow-xl backdrop-blur"
-      style={{
-        backgroundColor: "var(--app-surface)",
-        borderColor: "var(--app-border)",
-        color: "var(--app-text)",
-        boxShadow: "0 24px 48px var(--app-card-shadow)",
-      }}
-    >
+    <Card className="app-surface mx-auto w-full max-w-3xl border shadow-xl backdrop-blur">
       <CardContent className="p-5 sm:p-7">
         <form onSubmit={handleSubmit} className="space-y-5">
           <fieldset className="space-y-2.5">
@@ -114,11 +106,6 @@ export function SearchForm({
               onChange={handleUrlChange}
               disabled={isLoading}
               className="app-input h-12 w-full rounded-lg border px-4 shadow-inner transition-colors focus:ring-2 focus:outline-none"
-              style={{
-                backgroundColor: "var(--app-input-bg)",
-                borderColor: "var(--app-input-border)",
-                color: "var(--app-text)",
-              }}
               aria-describedby={
                 validationError
                   ? "url-error"
@@ -172,11 +159,6 @@ export function SearchForm({
             type="submit"
             disabled={isLoading || !url.trim()}
             className="app-primary-button h-12 w-full rounded-lg px-4 py-2 font-semibold shadow-lg transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
-            style={{
-              backgroundColor: "var(--app-button-bg)",
-              color: "var(--app-button-text)",
-              boxShadow: "0 10px 15px -3px var(--app-button-shadow)",
-            }}
             aria-describedby="url-help"
             aria-label={
               isLoading
@@ -198,13 +180,7 @@ export function SearchForm({
           </Button>
         </form>
 
-        <aside
-          className="app-muted mt-5 border-t border-[var(--app-border)] pt-4 text-sm leading-6"
-          style={{
-            borderColor: "var(--app-border)",
-            color: "var(--app-muted)",
-          }}
-        >
+        <aside className="app-muted mt-5 border-t border-[var(--app-border)] pt-4 text-sm leading-6">
           <p id="url-help" className="max-w-2xl">
             This tool automatically discovers RSS / Atom feeds for the website
             you specify.

--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,35 @@
 
 :root {
   --radius: 0.625rem;
+  --app-bg: #f8fafc;
+  --app-text: #020617;
+  --app-muted: #475569;
+  --app-placeholder: #94a3b8;
+  --app-border: rgb(226 232 240 / 0.85);
+  --app-header-bg: rgb(255 255 255 / 0.82);
+  --app-surface: rgb(255 255 255 / 0.92);
+  --app-surface-solid: #ffffff;
+  --app-control-bg: rgb(255 255 255 / 0.92);
+  --app-control-hover: #f1f5f9;
+  --app-input-bg: rgb(248 250 252 / 0.85);
+  --app-input-border: #e2e8f0;
+  --app-input-shadow: rgb(226 232 240 / 0.6);
+  --app-code-bg: #f8fafc;
+  --app-card-shadow: rgb(226 232 240 / 0.6);
+  --app-button-bg: #0d9488;
+  --app-button-hover: #0f766e;
+  --app-button-text: #ffffff;
+  --app-button-shadow: rgb(13 148 136 / 0.2);
+  --app-accent: #0f766e;
+  --app-accent-soft: #f0fdfa;
+  --app-accent-border: #99f6e4;
+  --app-focus: #14b8a6;
+  --app-focus-soft: rgb(20 184 166 / 0.2);
+  --app-hero-glow: radial-gradient(
+    circle at 50% 0%,
+    rgb(20 184 166 / 0.18),
+    transparent 58%
+  );
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -79,7 +108,37 @@
   --sidebar-ring: oklch(0.708 0 0);
 }
 
+:root[data-theme="dark"],
 .dark {
+  --app-bg: #0b1118;
+  --app-text: #ffffff;
+  --app-muted: #cbd5e1;
+  --app-placeholder: #64748b;
+  --app-border: rgb(255 255 255 / 0.1);
+  --app-header-bg: rgb(11 17 24 / 0.82);
+  --app-surface: rgb(255 255 255 / 0.06);
+  --app-surface-solid: #111c27;
+  --app-control-bg: rgb(255 255 255 / 0.05);
+  --app-control-hover: rgb(255 255 255 / 0.1);
+  --app-input-bg: #0d1823;
+  --app-input-border: rgb(255 255 255 / 0.1);
+  --app-input-shadow: transparent;
+  --app-code-bg: #0b1118;
+  --app-card-shadow: rgb(0 0 0 / 0.2);
+  --app-button-bg: #0ea5e9;
+  --app-button-hover: #38bdf8;
+  --app-button-text: #020617;
+  --app-button-shadow: rgb(14 165 233 / 0.2);
+  --app-accent: #7dd3fc;
+  --app-accent-soft: rgb(56 189 248 / 0.1);
+  --app-accent-border: rgb(56 189 248 / 0.35);
+  --app-focus: #38bdf8;
+  --app-focus-soft: rgb(56 189 248 / 0.2);
+  --app-hero-glow: radial-gradient(
+    circle at 50% 0%,
+    rgb(56 189 248 / 0.2),
+    transparent 58%
+  );
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -120,4 +179,85 @@
   body {
     @apply bg-background text-foreground font-sans;
   }
+}
+
+.app-shell {
+  background-color: var(--app-bg);
+  color: var(--app-text);
+}
+
+.app-hero-glow {
+  background-image: var(--app-hero-glow);
+}
+
+.app-header {
+  background-color: var(--app-header-bg);
+  border-color: var(--app-border);
+}
+
+.app-surface {
+  background-color: var(--app-surface);
+  border-color: var(--app-border);
+  color: var(--app-text);
+  box-shadow: 0 24px 48px var(--app-card-shadow);
+}
+
+.app-muted {
+  color: var(--app-muted);
+}
+
+.app-accent-text {
+  color: var(--app-accent);
+}
+
+.app-accent-box {
+  background-color: var(--app-accent-soft);
+  border-color: var(--app-accent-border);
+  color: var(--app-accent);
+}
+
+.app-control {
+  background-color: var(--app-control-bg);
+  border-color: var(--app-border);
+  color: var(--app-muted);
+  --tw-ring-color: var(--app-focus);
+  --tw-ring-offset-color: var(--app-bg);
+}
+
+.app-control:hover {
+  background-color: var(--app-control-hover);
+  color: var(--app-text);
+}
+
+.app-input {
+  background-color: var(--app-input-bg);
+  border-color: var(--app-input-border);
+  color: var(--app-text);
+  --tw-shadow-color: var(--app-input-shadow);
+  --tw-ring-color: var(--app-focus-soft);
+}
+
+.app-input::placeholder {
+  color: var(--app-placeholder);
+}
+
+.app-input:focus {
+  border-color: var(--app-focus);
+}
+
+.app-primary-button {
+  background-color: var(--app-button-bg);
+  color: var(--app-button-text);
+  --tw-shadow-color: var(--app-button-shadow);
+  --tw-ring-color: var(--app-focus);
+  --tw-ring-offset-color: var(--app-surface-solid);
+}
+
+.app-primary-button:hover {
+  background-color: var(--app-button-hover);
+}
+
+.app-code-block {
+  background-color: var(--app-code-bg);
+  border-color: var(--app-input-border);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -68,7 +68,7 @@
   --app-accent: #0f766e;
   --app-accent-soft: #f0fdfa;
   --app-accent-border: #99f6e4;
-  --app-focus: #14b8a6;
+  --app-focus: #0d9488;
   --app-focus-soft: rgb(20 184 166 / 0.2);
   --app-hero-glow: radial-gradient(
     circle at 50% 0%,
@@ -206,6 +206,10 @@
   color: var(--app-muted);
 }
 
+.app-text {
+  color: var(--app-text) !important;
+}
+
 .app-accent-text {
   color: var(--app-accent);
 }
@@ -219,7 +223,7 @@
 .app-control {
   background-color: var(--app-control-bg);
   border-color: var(--app-border);
-  color: var(--app-muted);
+  color: var(--app-text) !important;
   --tw-ring-color: var(--app-focus);
   --tw-ring-offset-color: var(--app-bg);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -265,3 +265,14 @@
   background-color: var(--app-code-bg);
   border-color: var(--app-input-border);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyTheme,
+  getInitialTheme,
+  THEME_COLORS,
+  THEME_STORAGE_KEY,
+} from "./theme";
+
+function mockColorSchemePreference(prefersDark: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(prefers-color-scheme: dark)" && prefersDark,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function ensureMetaThemeColor(initialContent = "#ffffff") {
+  document
+    .querySelectorAll('meta[name="theme-color"]')
+    .forEach((node) => node.remove());
+
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", "theme-color");
+  meta.setAttribute("content", initialContent);
+  document.head.appendChild(meta);
+  return meta;
+}
+
+describe("theme module", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.style.colorScheme = "";
+    document
+      .querySelectorAll('meta[name="theme-color"]')
+      .forEach((node) => node.remove());
+    mockColorSchemePreference(false);
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe("getInitialTheme", () => {
+    it("returns saved 'light' when localStorage has it", () => {
+      window.localStorage.setItem(THEME_STORAGE_KEY, "light");
+      expect(getInitialTheme()).toBe("light");
+    });
+
+    it("returns saved 'dark' when localStorage has it", () => {
+      window.localStorage.setItem(THEME_STORAGE_KEY, "dark");
+      expect(getInitialTheme()).toBe("dark");
+    });
+
+    it("ignores invalid localStorage values and falls back to system preference", () => {
+      window.localStorage.setItem(THEME_STORAGE_KEY, "purple");
+      mockColorSchemePreference(true);
+      expect(getInitialTheme()).toBe("dark");
+    });
+
+    it("returns 'dark' when system prefers dark and no theme is saved", () => {
+      mockColorSchemePreference(true);
+      expect(getInitialTheme()).toBe("dark");
+    });
+
+    it("returns 'light' when system prefers light and no theme is saved", () => {
+      mockColorSchemePreference(false);
+      expect(getInitialTheme()).toBe("light");
+    });
+  });
+
+  describe("applyTheme", () => {
+    beforeEach(() => {
+      ensureMetaThemeColor();
+    });
+
+    it("adds the 'dark' class on the html element for dark theme", () => {
+      applyTheme("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+    });
+
+    it("removes the 'dark' class on the html element for light theme", () => {
+      document.documentElement.classList.add("dark");
+      applyTheme("light");
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+    });
+
+    it("sets data-theme to the active theme", () => {
+      applyTheme("dark");
+      expect(document.documentElement.dataset["theme"]).toBe("dark");
+    });
+
+    it("sets colorScheme style to the active theme", () => {
+      applyTheme("light");
+      expect(document.documentElement.style.colorScheme).toBe("light");
+    });
+
+    it("syncs meta[name=theme-color] for dark theme", () => {
+      applyTheme("dark");
+      const meta = document.querySelector('meta[name="theme-color"]');
+      expect(meta?.getAttribute("content")).toBe(THEME_COLORS.dark);
+    });
+
+    it("syncs meta[name=theme-color] for light theme", () => {
+      applyTheme("light");
+      const meta = document.querySelector('meta[name="theme-color"]');
+      expect(meta?.getAttribute("content")).toBe(THEME_COLORS.light);
+    });
+
+    it("does not throw when meta[name=theme-color] is missing", () => {
+      document
+        .querySelectorAll('meta[name="theme-color"]')
+        .forEach((node) => node.remove());
+      expect(() => applyTheme("dark")).not.toThrow();
+    });
+
+    it("persists the theme to localStorage", () => {
+      applyTheme("dark");
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    });
+  });
+});

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -6,6 +6,8 @@ import {
   THEME_STORAGE_KEY,
 } from "./theme";
 
+const realLocalStorage = window.localStorage;
+
 function mockColorSchemePreference(prefersDark: boolean) {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
@@ -34,6 +36,19 @@ function ensureMetaThemeColor(initialContent = "#ffffff") {
   return meta;
 }
 
+function mockLocalStorageAccess(overrides: Partial<Storage>) {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      clear: vi.fn(),
+      getItem: vi.fn(() => null),
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+      ...overrides,
+    },
+  });
+}
+
 describe("theme module", () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -47,6 +62,10 @@ describe("theme module", () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: realLocalStorage,
+    });
     window.localStorage.clear();
     vi.restoreAllMocks();
   });
@@ -76,6 +95,17 @@ describe("theme module", () => {
     it("returns 'light' when system prefers light and no theme is saved", () => {
       mockColorSchemePreference(false);
       expect(getInitialTheme()).toBe("light");
+    });
+
+    it("falls back to system preference when localStorage cannot be read", () => {
+      mockLocalStorageAccess({
+        getItem: vi.fn(() => {
+          throw new Error("localStorage is blocked");
+        }),
+      });
+      mockColorSchemePreference(true);
+
+      expect(getInitialTheme()).toBe("dark");
     });
   });
 
@@ -127,6 +157,18 @@ describe("theme module", () => {
     it("persists the theme to localStorage", () => {
       applyTheme("dark");
       expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    });
+
+    it("does not throw when localStorage cannot be written", () => {
+      mockLocalStorageAccess({
+        setItem: vi.fn(() => {
+          throw new Error("localStorage is blocked");
+        }),
+      });
+
+      expect(() => applyTheme("dark")).not.toThrow();
+      expect(document.documentElement.dataset["theme"]).toBe("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
     });
   });
 });

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,1 +1,40 @@
 export const THEME_STORAGE_KEY = "feed-finder-theme";
+
+export const THEME_COLORS = {
+  light: "#f8fafc",
+  dark: "#0b1118",
+} as const;
+
+export type Theme = keyof typeof THEME_COLORS;
+
+export function getInitialTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (storedTheme === "light" || storedTheme === "dark") {
+    return storedTheme;
+  }
+
+  if (typeof window.matchMedia !== "function") {
+    return "light";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function applyTheme(theme: Theme): void {
+  const root = document.documentElement;
+  root.classList.toggle("dark", theme === "dark");
+  root.dataset["theme"] = theme;
+  root.style.colorScheme = theme;
+
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute("content", THEME_COLORS[theme]);
+
+  window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,1 @@
+export const THEME_STORAGE_KEY = "feed-finder-theme";

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,3 +1,5 @@
+import { Result } from "neverthrow";
+
 export const THEME_STORAGE_KEY = "feed-finder-theme";
 
 export const THEME_COLORS = {
@@ -7,12 +9,23 @@ export const THEME_COLORS = {
 
 export type Theme = keyof typeof THEME_COLORS;
 
+const safeGetStoredTheme = Result.fromThrowable(
+  () => window.localStorage.getItem(THEME_STORAGE_KEY),
+  () => null,
+);
+
+const safeSetStoredTheme = Result.fromThrowable(
+  (theme: Theme) => window.localStorage.setItem(THEME_STORAGE_KEY, theme),
+  () => undefined,
+);
+
 export function getInitialTheme(): Theme {
   if (typeof window === "undefined") {
     return "light";
   }
 
-  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  const storedThemeResult = safeGetStoredTheme();
+  const storedTheme = storedThemeResult.isOk() ? storedThemeResult.value : null;
   if (storedTheme === "light" || storedTheme === "dark") {
     return storedTheme;
   }
@@ -36,5 +49,5 @@ export function applyTheme(theme: Theme): void {
     .querySelector('meta[name="theme-color"]')
     ?.setAttribute("content", THEME_COLORS[theme]);
 
-  window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  safeSetStoredTheme(theme);
 }


### PR DESCRIPTION
## Summary

Introduce a light/dark theme toggle and refresh the overall visual design of Feed Finder. The app previously rendered with a single dark color scheme; this PR adds a CSS-custom-property-based theme system, a header toggle button, and persisted user preference, and brings the form, card, badge, and alert components in line with the new tokens so they read well on the light theme.

## Related Issue

n/a

## Changes

- Add a header theme toggle (sun/moon icon) with `aria-label`, `aria-pressed`, and a 44×44 touch target; initial value follows `prefers-color-scheme`, user choice persists in `localStorage`
- Introduce CSS custom properties for theme tokens (`--app-bg`, `--app-text`, `--app-surface`, etc.) in `src/index.css` and expose them through reusable utility classes (`.app-surface`, `.app-control`, `.app-input`, `.app-primary-button`)
- Centralize theme logic in `src/lib/theme.ts` (`Theme` type, `THEME_COLORS`, `getInitialTheme`, `applyTheme`) and have `App.tsx` import it instead of inlining the DOM-mutation code
- Add an inline init script in `index.html` that applies the theme and `meta[theme-color]` before first paint to prevent FOUC
- Sync `meta[name=theme-color]` on every toggle so iOS Safari's URL bar color follows the active theme
- Make the `loading-skeleton` placeholder theme-aware so it no longer looks dark on the light theme
- Honor `prefers-reduced-motion` in both `src/index.css` and the inline `<style>` block in `index.html` (WCAG 2.3.3)
- Add `src/lib/theme.test.ts` with 13 unit tests; expand `App.test.tsx` to cover system-preference fallback, saved-value precedence, toggle persistence, and `meta[theme-color]` sync

## Impact

- Visual: every page rendered by the SPA — both themes verified
- Accessibility: WCAG 2.2 AA targets retained (touch size, ARIA states); reduced-motion support added
- No backend / Worker changes
- No breaking API or schema changes

## Checklist

- [x] Code follows the style guidelines (Biome lint clean)
- [x] Tests added/updated (288 passed / 1 skipped)
- [x] Build is successful (\`npm run build\`)
- [x] Ready for review

## How to Test

```bash
npm run lint
npm run test:run
npm run build
npm run dev    # then toggle theme in the header
```

Manual spot-checks worth a quick spin:
- Toggle theme and refresh — saved choice restores without FOUC
- Clear \`feed-finder-theme\` from localStorage and switch the OS theme — initial render matches the OS preference
- iOS Safari (or DevTools mobile emulator): the URL bar color updates on toggle
- DevTools → Rendering → emulate \`prefers-color-scheme: reduce\` motion — animations and transitions collapse

## Additional Information

Subscribing to live OS-theme changes after first paint (only while no user choice is saved) was intentionally deferred per code-review feedback. It can ship in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)