### PR TITLE
test: Stabilize accessibility tests against lazy loading

### DIFF
--- a/src/accessibility.test.tsx
+++ b/src/accessibility.test.tsx
@@ -1,13 +1,92 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import App from "./App";
 
+async function renderAppAfterLazyBoundary() {
+  render(<App />);
+
+  await waitFor(() => {
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+  });
+}
+
 // t-wada style TDD: accessibility tests
 describe("Accessibility Tests (WCAG 2.2)", () => {
-  describe("Semantic HTML Structure", () => {
-    it("should have proper document structure with header and main elements", () => {
-      // Red Phase: Test semantic HTML elements
+  describe("ARIA Labels and Live Regions", () => {
+    it("should have proper aria-live regions for dynamic content", async () => {
+      // Red Phase: Test aria-live attributes for dynamic announcements
       render(<App />);
+
+      // Loading fallback should have aria-live before the lazy boundary settles
+      const loadingStatus = screen.getByRole("status");
+      expect(loadingStatus).toHaveTextContent("Loading...");
+      expect(loadingStatus).toHaveAttribute("aria-live", "polite");
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+      });
+    });
+
+    it("should have proper aria-label attributes on interactive elements", async () => {
+      // Red Phase: Test aria-label on buttons
+      await renderAppAfterLazyBoundary();
+
+      // Handle React StrictMode duplicate rendering by getting first match
+      const submitButtons = screen.getAllByRole("button", {
+        name: /Search feeds|Searching/,
+      });
+      expect(submitButtons[0]).toHaveAttribute("aria-label");
+    });
+
+    it("should have proper aria-describedby relationships", async () => {
+      // Red Phase: Test aria-describedby connections
+      await renderAppAfterLazyBoundary();
+
+      const urlInput = screen.getByLabelText(/Website URL/);
+      expect(urlInput).toHaveAttribute("aria-describedby");
+
+      const describedById = urlInput.getAttribute("aria-describedby");
+      expect(describedById).toBeTruthy();
+
+      // Referenced element should exist
+      const descriptionElement = document.getElementById(describedById!);
+      expect(descriptionElement).toBeInTheDocument();
+    });
+
+    it("should have proper aria-invalid for form validation", async () => {
+      // Red Phase: Test dynamic aria-invalid handling
+      await renderAppAfterLazyBoundary();
+
+      const urlInput = screen.getByLabelText(/Website URL/);
+
+      // Initially should be false or not set
+      expect(urlInput).toHaveAttribute("aria-invalid", "false");
+    });
+
+    it("should use aria-hidden on decorative icons", async () => {
+      // Red Phase: Test that decorative icons are hidden from screen readers
+      await renderAppAfterLazyBoundary();
+
+      // Icons should be marked as decorative
+      const icons = document.querySelectorAll("svg");
+
+      // Green Phase: Accept that some icons might not have aria-hidden yet
+      // This test will guide implementation
+      expect(icons.length).toBeGreaterThan(0);
+
+      // Future improvement: icons should have aria-hidden="true"
+      // This assertion will be enabled after implementation
+      // const hiddenIcons = Array.from(icons).filter(icon =>
+      //   icon.getAttribute('aria-hidden') === 'true'
+      // );
+      // expect(hiddenIcons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Semantic HTML Structure", () => {
+    it("should have proper document structure with header and main elements", async () => {
+      // Red Phase: Test semantic HTML elements
+      await renderAppAfterLazyBoundary();
 
       // Header element should exist
       const header = document.querySelector("header");
@@ -18,9 +97,9 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       expect(main).toBeInTheDocument();
     });
 
-    it("should have proper heading hierarchy starting with h1", () => {
+    it("should have proper heading hierarchy starting with h1", async () => {
       // Red Phase: Test heading hierarchy
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       // React StrictMode may cause duplicate rendering
       const h1Elements = document.querySelectorAll("h1");
@@ -46,9 +125,9 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       expect(siteTitle).toBeInTheDocument();
     });
 
-    it("should use section elements to structure content logically", () => {
+    it("should use section elements to structure content logically", async () => {
       // Red Phase: Test section elements
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       const sections = document.querySelectorAll("section");
       expect(sections.length).toBeGreaterThanOrEqual(2);
@@ -60,9 +139,9 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       expect(introSection).toBeInTheDocument();
     });
 
-    it("should use fieldset and legend for form grouping", () => {
+    it("should use fieldset and legend for form grouping", async () => {
       // Red Phase: Test form semantic structure (will fail initially)
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       const fieldset = document.querySelector("fieldset");
       expect(fieldset).toBeInTheDocument();
@@ -74,9 +153,9 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       expect(legend).toHaveClass("sr-only");
     });
 
-    it("should use aside element for supplementary information", () => {
+    it("should use aside element for supplementary information", async () => {
       // Red Phase: Test aside element usage
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       const aside = document.querySelector("aside");
       expect(aside).toBeInTheDocument();
@@ -87,82 +166,10 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
     });
   });
 
-  describe("ARIA Labels and Live Regions", () => {
-    it("should have proper aria-live regions for dynamic content", () => {
-      // Red Phase: Test aria-live attributes for dynamic announcements
-      render(<App />);
-
-      // Loading fallback should have aria-live
-      const loadingElements = document.querySelectorAll("[aria-live]");
-      expect(loadingElements.length).toBeGreaterThan(0);
-
-      // Should have polite announcements for non-critical updates
-      const politeAnnouncements = document.querySelectorAll(
-        '[aria-live="polite"]',
-      );
-      expect(politeAnnouncements.length).toBeGreaterThan(0);
-    });
-
-    it("should have proper aria-label attributes on interactive elements", () => {
-      // Red Phase: Test aria-label on buttons
-      render(<App />);
-
-      // Handle React StrictMode duplicate rendering by getting first match
-      const submitButtons = screen.getAllByRole("button", {
-        name: /Search feeds|Searching/,
-      });
-      expect(submitButtons[0]).toHaveAttribute("aria-label");
-    });
-
-    it("should have proper aria-describedby relationships", () => {
-      // Red Phase: Test aria-describedby connections
-      render(<App />);
-
-      const urlInput = screen.getByLabelText(/Website URL/);
-      expect(urlInput).toHaveAttribute("aria-describedby");
-
-      const describedById = urlInput.getAttribute("aria-describedby");
-      expect(describedById).toBeTruthy();
-
-      // Referenced element should exist
-      const descriptionElement = document.getElementById(describedById!);
-      expect(descriptionElement).toBeInTheDocument();
-    });
-
-    it("should have proper aria-invalid for form validation", () => {
-      // Red Phase: Test dynamic aria-invalid handling
-      render(<App />);
-
-      const urlInput = screen.getByLabelText(/Website URL/);
-
-      // Initially should be false or not set
-      expect(urlInput).toHaveAttribute("aria-invalid", "false");
-    });
-
-    it("should use aria-hidden on decorative icons", () => {
-      // Red Phase: Test that decorative icons are hidden from screen readers
-      render(<App />);
-
-      // Icons should be marked as decorative
-      const icons = document.querySelectorAll("svg");
-
-      // Green Phase: Accept that some icons might not have aria-hidden yet
-      // This test will guide implementation
-      expect(icons.length).toBeGreaterThan(0);
-
-      // Future improvement: icons should have aria-hidden="true"
-      // This assertion will be enabled after implementation
-      // const hiddenIcons = Array.from(icons).filter(icon =>
-      //   icon.getAttribute('aria-hidden') === 'true'
-      // );
-      // expect(hiddenIcons.length).toBeGreaterThan(0);
-    });
-  });
-
   describe("Keyboard Navigation", () => {
-    it("should support Tab navigation through interactive elements", () => {
+    it("should support Tab navigation through interactive elements", async () => {
       // Red Phase: Test Tab key navigation sequence
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       // Get all focusable elements in expected tab order
       const focusableElements = document.querySelectorAll(
@@ -171,18 +178,18 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       expect(focusableElements.length).toBeGreaterThan(0);
     });
 
-    it("should support Enter and Space key activation on interactive elements", () => {
+    it("should support Enter and Space key activation on interactive elements", async () => {
       // Red Phase: Test keyboard activation (will need implementation)
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       // Test form submission with Enter key
       const urlInput = screen.getByLabelText(/Website URL/);
       expect(urlInput).toHaveProperty("onkeydown");
     });
 
-    it("should have visible focus indicators", () => {
+    it("should have visible focus indicators", async () => {
       // Red Phase: Test focus ring implementation
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       const focusableElements = document.querySelectorAll("button, input");
       focusableElements.forEach((element) => {
@@ -192,9 +199,9 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       });
     });
 
-    it("should skip navigation on Escape key", () => {
+    it("should skip navigation on Escape key", async () => {
       // Red Phase: Test Escape key handling (future enhancement)
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       // For now, just verify we have the basic structure
       // This test will guide future implementation of Escape key handling
@@ -206,9 +213,9 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
   });
 
   describe("Focus Management (WCAG 2.2 Focus Not Obscured)", () => {
-    it("should ensure focused elements are not obscured by other content", () => {
+    it("should ensure focused elements are not obscured by other content", async () => {
       // Red Phase: Test Focus Not Obscured (WCAG 2.2 new requirement)
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       // Get all focusable elements
       const focusableElements = document.querySelectorAll(
@@ -232,9 +239,9 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       });
     });
 
-    it("should maintain focus visibility when content changes", () => {
+    it("should maintain focus visibility when content changes", async () => {
       // Red Phase: Test focus persistence during dynamic updates
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       const urlInput = screen.getByLabelText(/Website URL/);
       urlInput.focus();
@@ -246,9 +253,9 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       expect(urlInput.className).toMatch(/focus:/);
     });
 
-    it("should provide focus trap for modal dialogs", () => {
+    it("should provide focus trap for modal dialogs", async () => {
       // Red Phase: Test focus trapping (future modal implementation)
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       // For now, verify no modal exists (future enhancement)
       const modal = document.querySelector('[role="dialog"]');
@@ -258,9 +265,9 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       // Focus should be trapped within modal when open
     });
 
-    it("should restore focus when components unmount", () => {
+    it("should restore focus when components unmount", async () => {
       // Red Phase: Test focus restoration
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       // Focus the search input
       const urlInput = screen.getByLabelText(/Website URL/);
@@ -272,9 +279,9 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       expect(document.activeElement).toBeTruthy();
     });
 
-    it("should handle focus order correctly with dynamic content", () => {
+    it("should handle focus order correctly with dynamic content", async () => {
       // Red Phase: Test dynamic focus order
-      render(<App />);
+      await renderAppAfterLazyBoundary();
 
       // Test tab order is logical
       const focusableElements = Array.from(

--- a/src/accessibility.test.tsx
+++ b/src/accessibility.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
 
 async function renderAppAfterLazyBoundary() {
@@ -10,8 +10,39 @@ async function renderAppAfterLazyBoundary() {
   });
 }
 
+function mockSuccessfulSearchFetch() {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({
+      success: true,
+      feeds: [],
+      searchedUrl: "https://example.com",
+      totalFound: 0,
+    }),
+  });
+
+  vi.stubGlobal("fetch", fetchMock);
+
+  return fetchMock;
+}
+
+function getEnabledSearchButton() {
+  const buttons = screen.getAllByRole("button", { name: /Search feeds/ });
+  const enabledButton = buttons.find(
+    (button) => !button.hasAttribute("disabled"),
+  );
+
+  expect(enabledButton).toBeDefined();
+
+  return enabledButton!;
+}
+
 // t-wada style TDD: accessibility tests
 describe("Accessibility Tests (WCAG 2.2)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   describe("ARIA Labels and Live Regions", () => {
     it("should have proper aria-live regions for dynamic content", async () => {
       // Red Phase: Test aria-live attributes for dynamic announcements
@@ -63,19 +94,14 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
       expect(urlInput).toHaveAttribute("aria-invalid", "false");
     });
 
-    it("should use aria-hidden on decorative icons", async () => {
-      // Red Phase: Test that decorative icons are hidden from screen readers
+    it("should render SVG icons for decorative UI elements", async () => {
       await renderAppAfterLazyBoundary();
 
-      // Icons should be marked as decorative
       const icons = document.querySelectorAll("svg");
 
-      // Green Phase: Accept that some icons might not have aria-hidden yet
-      // This test will guide implementation
       expect(icons.length).toBeGreaterThan(0);
 
-      // Future improvement: icons should have aria-hidden="true"
-      // This assertion will be enabled after implementation
+      // TODO: Enable after adding aria-hidden="true" to decorative SVGs in production.
       // const hiddenIcons = Array.from(icons).filter(icon =>
       //   icon.getAttribute('aria-hidden') === 'true'
       // );
@@ -179,12 +205,37 @@ describe("Accessibility Tests (WCAG 2.2)", () => {
     });
 
     it("should support Enter and Space key activation on interactive elements", async () => {
-      // Red Phase: Test keyboard activation (will need implementation)
+      const fetchMock = mockSuccessfulSearchFetch();
       await renderAppAfterLazyBoundary();
 
-      // Test form submission with Enter key
       const urlInput = screen.getByLabelText(/Website URL/);
-      expect(urlInput).toHaveProperty("onkeydown");
+      fireEvent.change(urlInput, { target: { value: "example.com" } });
+
+      fireEvent.keyDown(urlInput, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        "/api/search-feeds",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ url: "https://example.com" }),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(getEnabledSearchButton()).toBeEnabled();
+      });
+
+      fireEvent.keyDown(getEnabledSearchButton(), {
+        key: " ",
+        code: "Space",
+      });
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
     });
 
     it("should have visible focus indicators", async () => {


### PR DESCRIPTION
## Summary
- Stabilize `src/accessibility.test.tsx` so it waits for `App`'s lazy `ResultDisplay` boundary before asserting on the DOM.
- Keep the production `React.lazy` split intact while removing the CI flake caused by tests finishing before Suspense settles.
- Preserve the aria-live coverage by checking the loading fallback first, then waiting for the lazy content to resolve.

## Related Issue
- Closes #43

## Changes
- Added a small helper to render `App` and wait for the lazy boundary to settle.
- Converted the accessibility cases to `async` and used the helper for shared setup.
- Kept the aria-live test focused on the initial loading fallback before waiting for resolution.
- Left production code and global test teardown unchanged.

## Testing
- `npm run test:run -- src/accessibility.test.tsx`
- 20 consecutive runs of `src/accessibility.test.tsx`
- `npm run test:run`
- `npm run lint`
- `npm run test:coverage`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * アクセシビリティテストが非同期対応され、遅延読み込みコンテンツの確認後にアサーションが実行されるよう改善されました。
  * キーボードナビゲーション、フォーカス管理、セマンティックHTML関連のテストカバレッジが拡張されました。
  * ARIA属性とキーボード操作のテストが強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->