### PR TITLE
refactor: harden console policy and stabilize ARIA labelledby IDs

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,10 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": [
-      "**",
-      "!worker-configuration.d.ts"
-    ]
+    "includes": ["**", "!worker-configuration.d.ts"]
   },
   "formatter": {
     "enabled": true,
@@ -21,10 +18,7 @@
     "rules": {
       "recommended": false
     },
-    "includes": [
-      "**",
-      "!dist"
-    ]
+    "includes": ["**", "!dist"]
   },
   "javascript": {
     "formatter": {
@@ -38,13 +32,9 @@
   },
   "overrides": [
     {
-      "includes": [
-        "**/*.{ts,tsx}"
-      ],
+      "includes": ["**/*.{ts,tsx}"],
       "javascript": {
-        "globals": [
-          "browser"
-        ]
+        "globals": ["browser"]
       },
       "linter": {
         "rules": {
@@ -99,6 +89,12 @@
             "noCatchAssign": "error",
             "noClassAssign": "error",
             "noCompareNegZero": "error",
+            "noConsole": {
+              "level": "error",
+              "options": {
+                "allow": ["error", "warn"]
+              }
+            },
             "noControlCharactersInRegex": "error",
             "noDebugger": "error",
             "noDuplicateCase": "error",

--- a/src/components/ResultDisplay.test.tsx
+++ b/src/components/ResultDisplay.test.tsx
@@ -316,6 +316,26 @@ describe("ResultDisplay", () => {
         expect(document.getElementById(labelledby!)).toBeTruthy();
       });
     });
+
+    it("should generate unique labelledby targets across result displays", () => {
+      render(
+        <>
+          <ResultDisplay result={successResult} />
+          <ResultDisplay result={successResult} />
+        </>,
+      );
+
+      const articles = document.querySelectorAll("article[aria-labelledby]");
+      const labelledbyValues = Array.from(articles).map((article) =>
+        article.getAttribute("aria-labelledby"),
+      );
+
+      expect(new Set(labelledbyValues).size).toBe(labelledbyValues.length);
+      labelledbyValues.forEach((labelledby) => {
+        expect(labelledby).toBeTruthy();
+        expect(document.getElementById(labelledby!)).toBeTruthy();
+      });
+    });
   });
 
   describe("URL copy functionality", () => {

--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CheckCircle, Copy, ExternalLink, Info, XCircle } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import type { FeedResult, SearchResult } from "../../shared/types";
@@ -13,6 +13,7 @@ interface ResultDisplayProps {
 
 export function ResultDisplay({ result, error }: ResultDisplayProps) {
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
+  const resultId = useId();
 
   const handleCopyUrl = async (url: string) => {
     try {
@@ -100,7 +101,7 @@ export function ResultDisplay({ result, error }: ResultDisplayProps) {
           <li key={`${feed.url}-${index}`} role="listitem">
             <FeedCard
               feed={feed}
-              itemId={`feed-${index}`}
+              titleId={`${resultId}-feed-${index}-title`}
               onCopyUrl={handleCopyUrl}
               onOpenFeed={handleOpenFeed}
               copiedUrl={copiedUrl}
@@ -114,7 +115,7 @@ export function ResultDisplay({ result, error }: ResultDisplayProps) {
 
 interface FeedCardProps {
   feed: FeedResult;
-  itemId: string;
+  titleId: string;
   onCopyUrl: (url: string) => void;
   onOpenFeed: (url: string) => void;
   copiedUrl: string | null;
@@ -122,13 +123,12 @@ interface FeedCardProps {
 
 function FeedCard({
   feed,
-  itemId,
+  titleId,
   onCopyUrl,
   onOpenFeed,
   copiedUrl,
 }: FeedCardProps) {
   const isUrlCopied = copiedUrl === feed.url;
-  const feedTitleId = `${itemId}-title-${feed.url.replace(/[^a-zA-Z0-9]/g, "-")}`;
   const discoveryMethodText =
     feed.discoveryMethod === "meta-tag"
       ? "Discovered via HTML meta tag"
@@ -137,13 +137,13 @@ function FeedCard({
   return (
     <article
       className="app-surface rounded-lg border shadow-lg transition-colors duration-200 hover:border-[var(--app-accent-border)]"
-      aria-labelledby={feedTitleId}
+      aria-labelledby={titleId}
     >
       <header className="p-6 pb-3">
         <div className="flex items-start justify-between">
           <div className="flex-1 min-w-0">
             <h3
-              id={feedTitleId}
+              id={titleId}
               className="app-text truncate text-lg font-semibold leading-tight"
             >
               {feed.title || feed.url}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,9 @@ export default defineConfig({
     minify: "oxc",
     // Code splitting configuration
     rollupOptions: {
+      treeshake: {
+        manualPureFunctions: ["console.log", "console.info", "console.debug"],
+      },
       output: {
         manualChunks(id) {
           // Separate vendor dependencies

--- a/worker/discovery/html.test.ts
+++ b/worker/discovery/html.test.ts
@@ -85,6 +85,16 @@ describe("discovery/html", () => {
       );
     });
 
+    it("should handle HTML whitespace around attribute separators", () => {
+      const tag =
+        '<link href\n=\r"https://example.com/feed.xml" rel\f=\n"alternate">';
+
+      expect(extractAttributeValue(tag, "href")).toBe(
+        "https://example.com/feed.xml",
+      );
+      expect(extractAttributeValue(tag, "rel")).toBe("alternate");
+    });
+
     it("should return null for missing attributes", () => {
       const tag = '<link href="https://example.com/feed.xml">';
       expect(extractAttributeValue(tag, "rel")).toBe(null);
@@ -335,6 +345,29 @@ describe("discovery/html", () => {
     it("should handle whitespace around fallback attribute separators", () => {
       const html =
         '<link rel = "alternate" type = "application/rss+xml" href = "/feed.xml">';
+
+      const result = findMetaFeedsWithStringParsing(html, baseUrl);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].url).toBe("https://example.com/feed.xml");
+    });
+
+    it("should handle multiline fallback link attributes", () => {
+      const html = `<link
+        rel="alternate"
+        type="application/rss+xml"
+        href="/feed.xml"
+      >`;
+
+      const result = findMetaFeedsWithStringParsing(html, baseUrl);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].url).toBe("https://example.com/feed.xml");
+    });
+
+    it("should trim feed MIME values in fallback parsing", () => {
+      const html =
+        '<link rel="alternate" type=" application/rss+xml ; charset=utf-8" href="/feed.xml">';
 
       const result = findMetaFeedsWithStringParsing(html, baseUrl);
 

--- a/worker/integration.test.ts
+++ b/worker/integration.test.ts
@@ -277,18 +277,8 @@ describe("Security Integration Tests", () => {
         // No closing '>' - this will cause catastrophic backtracking in vulnerable regex
         'rel="alternate" type="application/rss+xml" href="/feed.xml"';
 
-      // TODO: Use vi.useFakeTimers() for deterministic testing instead of performance.now()
-      const startTime = performance.now();
-
       // Test the potentially vulnerable function
       const feeds = findMetaFeeds(maliciousHtml, "https://example.com");
-
-      const endTime = performance.now();
-      const executionTime = endTime - startTime;
-
-      // For now, document that the current implementation is vulnerable
-      // A secure implementation should complete in < 10ms
-      console.log(`findMetaFeeds execution time: ${executionTime}ms`);
 
       // Test expectation: secure implementation should be fast and safe
       expect(feeds).toBeDefined();


### PR DESCRIPTION
## Overview

This is a refactoring follow-up that tightens two long-standing rough edges in the codebase: ad-hoc `console` usage and ARIA `aria-labelledby` IDs that were derived from feed URLs.

The console hardening enables Biome's `noConsole` rule across the linted source tree — `src/` and `worker/`, which is what `npm run lint` and CI scan — allowing only `console.error` / `console.warn`. It also teaches the production Vite build to treat `console.log/info/debug` as pure for tree-shaking, so any stragglers are dropped from the bundle. The integration-test `console.log` that was previously documenting a regex-DoS measurement is removed. Note: top-level config files (`vite.config.ts`, `vitest.config.ts`) and `shared/` are outside the lint invocation scope, so the rule does not currently fail CI for those paths; widening the scope is left as a follow-up.

The ARIA fix replaces URL-based ID generation in `ResultDisplay` / `FeedCard` with React's `useId()`, threading a `titleId` prop down to each card. This guarantees unique, stable, valid IDs even when two `ResultDisplay` instances render the same feed URL on the same page, which the previous string-sanitization approach could collide on.

A handful of HTML-discovery edge cases (whitespace around `=` in attributes, multiline `<link>` tags, and MIME types with surrounding whitespace or charset suffixes) gain explicit regression tests so the fallback parser stays well-defined.

## Related Issue

n/a

## Changes

- Enable Biome `noConsole` lint rule with `error`/`warn` allow-list
- Configure Vite Rollup tree-shake to mark `console.log/info/debug` as pure functions
- Replace URL-derived `aria-labelledby` IDs in `ResultDisplay` with `useId()`-based unique IDs and rename the prop from `itemId` to `titleId`
- Add a `ResultDisplay` test asserting unique `aria-labelledby` targets across multiple instances
- Add discovery tests for whitespace around attribute separators, multiline `<link>` tags, and trimmed feed MIME types
- Drop the leftover `performance.now()` timing block and `console.log` in the regex-DoS integration test
- Minor `biome.json` formatting (single-line array literals)

## Impact Scope

- Frontend: `ResultDisplay` rendering — accessibility-only change, no visible UI difference
- Production bundle: `console.log/info/debug` calls are now stripped during build
- Lint: any newly added `console.log` under `src/` or `worker/` will fail CI; use `console.error` / `console.warn` when intentional. Files outside that scope (e.g. `vite.config.ts`, `vitest.config.ts`, `shared/`) are not linted today
- No worker runtime / API surface changes

## Checklist

- [ ] Code follows the style guidelines
- [ ] Tests have been added/updated
- [ ] Documentation has been updated (if relevant)
- [ ] Build is successful
- [ ] Ready for review

## How to Test

- \`npm run lint\` — Biome should pass with the new \`noConsole\` rule active
- \`npm run test:run\` — covers the new \`ResultDisplay\` uniqueness test and added \`worker/discovery/html\` cases
- \`npm run build\` — verify production build still succeeds with the updated tree-shake config

## Additional Information

- The \`noConsole\` allow-list intentionally keeps \`error\` and \`warn\` so genuine diagnostics still surface; debug-style logging should go through dedicated tooling rather than being re-added.
- \`useId()\` requires React 18+, which this project already targets (React 19).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリース ノート

* **バグ修正**
  * ResultDisplay コンポーネントのアクセシビリティを改善し、aria-labelledby の一意性を確保

* **テスト**
  * アクセシビリティテストを拡張して複数結果のシナリオをカバー
  * HTML 属性解析とマルチラインタグの処理に関するテストカバレッジを追加

* **Chores**
  * ビルド最適化設定とリント設定を更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
