### PR TITLE
ci: Migrate deploy to Cloudflare Workers Builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,29 +55,3 @@ jobs:
 
     - name: Build project
       run: npm run build
-
-
-  deploy:
-    runs-on: ubuntu-24.04
-    needs: [test, lint-and-typecheck]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Deploy to Cloudflare Workers
-        run: npm run deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,7 @@
   "name": "feed-finder",
   "main": "worker/index.ts",
   "compatibility_date": "2025-05-05",
+  "preview_urls": true,
   "assets": {
     "directory": "./dist",
     "not_found_handling": "single-page-application"


### PR DESCRIPTION
## Overview

The Cloudflare dashboard displayed deploys as "Wrangler by Unknown" because API-token deploys do not carry a deployer identity. This PR migrates deployment from GitHub Actions to **Cloudflare Workers Builds** (Cloudflare's native CI/CD), which records each deploy with a clear source ("Workers Builds"), commit SHA, branch, and PR link. Since 2025-06, Workers Builds also injects the commit SHA and branch name as build-time environment variables.

Cloudflare's official docs recommend Workers Builds as the first choice for GitHub/GitLab users. We keep test / lint / type-check jobs in GitHub Actions as PR gates — the hybrid pattern Cloudflare recommends.

## Related Issue

n/a

## Changes

- Remove the `deploy` job from `.github/workflows/ci.yml` (Workers Builds replaces it)
- Add `preview_urls: true` to `wrangler.jsonc` so Workers Builds can publish per-commit preview URLs
- Workers Builds settings configured in the Cloudflare dashboard (already done):
  - Repo: `takuan-osho/feed-finder` connected
  - Build command: `npm ci && npm run build`
  - Deploy command: `npx wrangler deploy`
  - Production branch: `main`
  - Build cache: enabled

## Impact Scope

- **CI/CD only.** No changes to Worker runtime behavior, public endpoints, or bindings.
- After this merges, pushes to `main` will be built and deployed automatically by Cloudflare.
- The GitHub Secrets `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are no longer referenced by GitHub Actions and can be deleted manually as a follow-up. (The API token used by Workers Builds itself is a separate one managed by the dashboard.)

## Checklist

- [x] Code follows the style guidelines
- [x] Tests have been added/updated (n/a — CI config only)
- [x] Documentation has been updated (n/a)
- [x] Build is successful (lefthook pre-commit passed)
- [x] Ready for review

## How to Test

1. Merge this PR.
2. In the Cloudflare dashboard, go to **Workers & Pages → feed-finder → Builds** and confirm a new build is triggered by Workers Builds and finishes successfully.
3. Open the **Deployments** tab and confirm the entry shows Workers Builds with commit info (SHA / branch / PR), not "Wrangler by Unknown".
4. Confirm the GitHub Actions `test` and `lint-and-typecheck` jobs still pass and the `deploy` job is gone.

## Additional Information

- The switch reduces GitHub Actions minutes previously spent on the deploy job; Workers Builds minutes are included in the Cloudflare plan.
- Follow-up: once Workers Builds is verified end-to-end, delete the now-unused GitHub Secrets (`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ワーカーのプレビューURL生成が有効になりました。

* **Chores**
  * CI パイプラインでビルドステップを実行するようになりました。
  * CI からの自動デプロイメント機能が削除されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->