### PR TITLE
feat: Add structured JSON logs and HTTP access logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "lucide-react": "^1.11.0",
         "neverthrow": "^8.2.0",
         "node-html-parser": "^7.1.0",
+        "pino": "^10.3.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "tailwind-merge": "^3.5.0",
@@ -1970,6 +1971,12 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
@@ -3373,7 +3380,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -3475,6 +3482,15 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -4935,6 +4951,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5068,6 +5093,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/postcss": {
       "version": "8.5.11",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.11.tgz",
@@ -5123,6 +5185,22 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5132,6 +5210,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.5",
@@ -5161,6 +5245,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -5224,6 +5317,15 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -5334,6 +5436,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5341,6 +5452,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -5417,6 +5537,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lucide-react": "^1.11.0",
     "neverthrow": "^8.2.0",
     "node-html-parser": "^7.1.0",
+    "pino": "^10.3.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tailwind-merge": "^3.5.0",

--- a/worker/http/errors.test.ts
+++ b/worker/http/errors.test.ts
@@ -174,7 +174,7 @@ describe("http/errors", () => {
       );
     });
 
-    it("should log error details with generated ID", () => {
+    it("should log error details as a structured JSON line", () => {
       const error = {
         type: "NETWORK_ERROR" as const,
         message: "Connection refused",
@@ -184,9 +184,19 @@ describe("http/errors", () => {
 
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
       const logCall = consoleErrorSpy.mock.calls[0][0];
-      expect(logCall).toMatch(
-        /^\[\w+\] Error type: NETWORK_ERROR, Details: Connection refused$/,
-      );
+      expect(typeof logCall).toBe("string");
+      const parsed = JSON.parse(logCall as string) as {
+        level: string;
+        msg: string;
+        error_type: string;
+        details: string;
+        error_id: string;
+      };
+      expect(parsed.level).toBe("error");
+      expect(parsed.msg).toBe("error_response");
+      expect(parsed.error_type).toBe("NETWORK_ERROR");
+      expect(parsed.details).toBe("Connection refused");
+      expect(parsed.error_id).toMatch(/^[a-z0-9]{9}$/);
     });
 
     it("should generate unique error IDs", async () => {

--- a/worker/http/errors.ts
+++ b/worker/http/errors.ts
@@ -1,3 +1,4 @@
+import { logger } from "../observability/logger";
 import type { AppError } from "../types";
 
 /**
@@ -33,8 +34,13 @@ export function generateErrorId(): string {
 export function createErrorResponse(error: AppError): Response {
   // Log detailed error information for debugging (server-side only)
   const errorId = generateErrorId();
-  console.error(
-    `[${errorId}] Error type: ${error.type}, Details: ${error.message}`,
+  logger.error(
+    {
+      error_id: errorId,
+      error_type: error.type,
+      details: error.message,
+    },
+    "error_response",
   );
 
   // Return generic user-friendly message to prevent information disclosure

--- a/worker/index.access-log.test.ts
+++ b/worker/index.access-log.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface AccessLog {
+  level: string;
+  msg?: string;
+  event?: string;
+  method?: string;
+  route?: string;
+  status_code?: number;
+  duration_ms?: number;
+  request_id?: string;
+}
+
+const findHttpAccess = (
+  spies: ReturnType<typeof vi.spyOn>[],
+): AccessLog | undefined => {
+  for (const spy of spies) {
+    for (const call of spy.mock.calls) {
+      const raw = call[0];
+      if (typeof raw !== "string") continue;
+      try {
+        const parsed = JSON.parse(raw) as AccessLog;
+        if (parsed.event === "http_access") return parsed;
+      } catch {
+        // ignore non-JSON
+      }
+    }
+  }
+  return undefined;
+};
+
+describe("worker access log", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits http_access info log for unknown path (404)", async () => {
+    const { default: worker } = await import("./index");
+    const request = new Request("https://test.com/nonexistent", {
+      method: "GET",
+    });
+    const response = await worker.fetch(request);
+
+    expect(response.status).toBe(404);
+
+    const access = findHttpAccess([logSpy, warnSpy, errSpy]);
+    expect(access).toBeDefined();
+    expect(access?.event).toBe("http_access");
+    expect(access?.method).toBe("GET");
+    expect(access?.route).toBe("/nonexistent");
+    expect(access?.status_code).toBe(404);
+    expect(typeof access?.duration_ms).toBe("number");
+    expect(access?.level).toBe("warn");
+  });
+
+  it("emits http_access info log on 200 (CORS preflight)", async () => {
+    const { default: worker } = await import("./index");
+    const request = new Request("https://test.com/api/search-feeds", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://feedfinder.programarch.com",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+    const response = await worker.fetch(request);
+
+    expect(response.status).toBeGreaterThanOrEqual(200);
+
+    const access = findHttpAccess([logSpy, warnSpy, errSpy]);
+    expect(access).toBeDefined();
+    expect(access?.method).toBe("OPTIONS");
+    expect(access?.route).toBe("/api/search-feeds");
+  });
+
+  it("propagates cf-ray as request_id when present", async () => {
+    const { default: worker } = await import("./index");
+    const request = new Request("https://test.com/missing", {
+      method: "GET",
+      headers: { "cf-ray": "abc123-xyz" },
+    });
+    await worker.fetch(request);
+
+    const access = findHttpAccess([logSpy, warnSpy, errSpy]);
+    expect(access?.request_id).toBe("abc123-xyz");
+  });
+});

--- a/worker/index.access-log.test.ts
+++ b/worker/index.access-log.test.ts
@@ -63,7 +63,7 @@ describe("worker access log", () => {
     expect(access?.level).toBe("warn");
   });
 
-  it("emits http_access info log on 200 (CORS preflight)", async () => {
+  it("emits http_access info log on 204 (CORS preflight)", async () => {
     const { default: worker } = await import("./index");
     const request = new Request("https://test.com/api/search-feeds", {
       method: "OPTIONS",
@@ -74,12 +74,14 @@ describe("worker access log", () => {
     });
     const response = await worker.fetch(request);
 
-    expect(response.status).toBeGreaterThanOrEqual(200);
+    expect(response.status).toBe(204);
 
     const access = findHttpAccess([logSpy, warnSpy, errSpy]);
     expect(access).toBeDefined();
     expect(access?.method).toBe("OPTIONS");
     expect(access?.route).toBe("/api/search-feeds");
+    expect(access?.status_code).toBe(204);
+    expect(access?.level).toBe("info");
   });
 
   it("propagates cf-ray as request_id when present", async () => {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -2,6 +2,7 @@ import { ResultAsync } from "neverthrow";
 import { discoverFeeds } from "./discovery";
 import { addSecurityHeaders, handleCorsPreflightRequest } from "./http/cors";
 import { createErrorResponse } from "./http/errors";
+import { logAccess } from "./observability/logger";
 import type { ValidationError } from "./types";
 import { normalizeUrl, parseRequestBody } from "./validation/request";
 import { validateTargetUrl } from "./validation/url";
@@ -36,27 +37,44 @@ async function handleFeedSearch(request: Request): Promise<Response> {
   );
 }
 
+async function dispatch(request: Request, url: URL): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return handleCorsPreflightRequest(request);
+  }
+
+  if (url.pathname.startsWith("/api/")) {
+    if (url.pathname === "/api/search-feeds" && request.method === "POST") {
+      const response = await handleFeedSearch(request);
+      return addSecurityHeaders(response, request);
+    }
+    return addSecurityHeaders(
+      new Response("Not Found", { status: 404 }),
+      request,
+    );
+  }
+
+  return addSecurityHeaders(new Response(null, { status: 404 }), request);
+}
+
 /**
  * Main Worker entry point
  */
 export default {
   async fetch(request: Request): Promise<Response> {
+    const start = Date.now();
     const url = new URL(request.url);
+    const requestId = request.headers.get("cf-ray") ?? undefined;
 
-    // Handle CORS preflight requests
-    if (request.method === "OPTIONS") {
-      return handleCorsPreflightRequest(request);
-    }
+    const response = await dispatch(request, url);
 
-    if (url.pathname.startsWith("/api/")) {
-      if (url.pathname === "/api/search-feeds" && request.method === "POST") {
-        const response = await handleFeedSearch(request);
-        return addSecurityHeaders(response, request);
-      }
-      const notFoundResponse = new Response("Not Found", { status: 404 });
-      return addSecurityHeaders(notFoundResponse, request);
-    }
-    const notFoundResponse = new Response(null, { status: 404 });
-    return addSecurityHeaders(notFoundResponse, request);
+    logAccess({
+      method: request.method,
+      route: url.pathname,
+      status_code: response.status,
+      duration_ms: Date.now() - start,
+      request_id: requestId,
+    });
+
+    return response;
   },
 };

--- a/worker/observability/logger.test.ts
+++ b/worker/observability/logger.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logAccess, logger } from "./logger";
+
+interface ParsedLog {
+  level: string;
+  msg?: string;
+  ts?: string;
+  service?: string;
+  event?: string;
+  status_code?: number;
+  duration_ms?: number;
+  method?: string;
+  route?: string;
+  request_id?: string;
+  error_type?: string;
+  error_id?: string;
+}
+
+const parseLastCall = (spy: ReturnType<typeof vi.spyOn>): ParsedLog => {
+  const calls = spy.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  const last = calls[calls.length - 1][0];
+  expect(typeof last).toBe("string");
+  return JSON.parse(last as string) as ParsedLog;
+};
+
+describe("observability/logger", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("pino logger", () => {
+    it("emits info as JSON via console.log with service and ts", () => {
+      logger.info({ request_id: "req-1" }, "worker started");
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const log = parseLastCall(logSpy);
+
+      expect(log.level).toBe("info");
+      expect(log.msg).toBe("worker started");
+      expect(log.request_id).toBe("req-1");
+      expect(log.service).toBe("feed-finder");
+      expect(log.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it("emits error as JSON via console.error", () => {
+      logger.error({ error_type: "FETCH_FAILED", error_id: "abc123" }, "boom");
+
+      expect(errSpy).toHaveBeenCalledTimes(1);
+      const log = parseLastCall(errSpy);
+
+      expect(log.level).toBe("error");
+      expect(log.msg).toBe("boom");
+      expect(log.error_type).toBe("FETCH_FAILED");
+      expect(log.error_id).toBe("abc123");
+    });
+
+    it("emits warn as JSON via console.warn", () => {
+      logger.warn({ kind: "deprecation" }, "old path");
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const log = parseLastCall(warnSpy);
+
+      expect(log.level).toBe("warn");
+      expect(log.msg).toBe("old path");
+    });
+  });
+
+  describe("logAccess", () => {
+    it("emits event=http_access with status_code, duration_ms, method, route", () => {
+      logAccess({
+        method: "POST",
+        route: "/api/search-feeds",
+        status_code: 200,
+        duration_ms: 123,
+        request_id: "req-xyz",
+      });
+
+      const log = parseLastCall(logSpy);
+      expect(log.event).toBe("http_access");
+      expect(log.level).toBe("info");
+      expect(log.status_code).toBe(200);
+      expect(log.duration_ms).toBe(123);
+      expect(log.method).toBe("POST");
+      expect(log.route).toBe("/api/search-feeds");
+      expect(log.request_id).toBe("req-xyz");
+    });
+
+    it("uses console.error when status_code >= 500", () => {
+      logAccess({
+        method: "POST",
+        route: "/api/search-feeds",
+        status_code: 502,
+        duration_ms: 10,
+      });
+
+      expect(errSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).not.toHaveBeenCalled();
+      const log = parseLastCall(errSpy);
+      expect(log.level).toBe("error");
+      expect(log.status_code).toBe(502);
+    });
+
+    it("uses console.warn for 4xx", () => {
+      logAccess({
+        method: "POST",
+        route: "/api/search-feeds",
+        status_code: 404,
+        duration_ms: 5,
+      });
+
+      const log = parseLastCall(warnSpy);
+      expect(log.level).toBe("warn");
+      expect(log.status_code).toBe(404);
+    });
+
+    it("rounds duration_ms to integer", () => {
+      logAccess({
+        method: "GET",
+        route: "/",
+        status_code: 200,
+        duration_ms: 12.7,
+      });
+
+      const log = parseLastCall(logSpy);
+      expect(log.duration_ms).toBe(13);
+    });
+  });
+});

--- a/worker/observability/logger.ts
+++ b/worker/observability/logger.ts
@@ -1,4 +1,4 @@
-import pino from "pino";
+import pino from "pino/browser";
 
 interface AccessFields {
   method: string;
@@ -8,37 +8,53 @@ interface AccessFields {
   request_id?: string;
 }
 
-const consoleDestination = {
-  write(chunk: string): void {
-    const line = chunk.endsWith("\n") ? chunk.slice(0, -1) : chunk;
-    let level: string | undefined;
-    try {
-      level = (JSON.parse(line) as { level?: string }).level;
-    } catch {
-      level = undefined;
-    }
-    if (level === "error" || level === "fatal") {
-      console.error(line);
-    } else if (level === "warn") {
-      console.warn(line);
-    } else {
-      // biome-ignore lint/suspicious/noConsole: pino destination — CF Workers Logs ingest console.log JSON
-      console.log(line);
-    }
-  },
+// Pino's Node entry uses node:diagnostics_channel and sonic-boom, which break in
+// Cloudflare Workers (see workerd discussion #3423). The browser entry is the
+// supported path; we still keep all output on the existing console channels so
+// Cloudflare Workers Logs / the Grafana drain ingest unchanged JSON lines.
+const formatLine = (level: string, o: object): string => {
+  // Drop pino's auto-added numeric `level` and epoch `time`; emit the string
+  // level label and an ISO `ts` instead so Loki/Grafana can index them.
+  // `service` is added here rather than via pino's `base` because base bindings
+  // are not auto-applied to root-logger calls in browser mode.
+  const stripped: Record<string, unknown> = {
+    ...(o as Record<string, unknown>),
+  };
+  delete stripped["level"];
+  delete stripped["time"];
+  return JSON.stringify({
+    level,
+    ts: new Date().toISOString(),
+    service: "feed-finder",
+    ...stripped,
+  });
 };
 
-export const logger = pino(
-  {
-    level: "info",
-    base: { service: "feed-finder" },
-    formatters: {
-      level: (label) => ({ level: label }),
+const writeError = (o: object): void => {
+  console.error(formatLine("error", o));
+};
+const writeWarn = (o: object): void => {
+  console.warn(formatLine("warn", o));
+};
+const writeInfo = (o: object): void => {
+  // biome-ignore lint/suspicious/noConsole: pino destination — CF Workers Logs ingest console.log JSON
+  console.log(formatLine("info", o));
+};
+
+export const logger = pino({
+  level: "info",
+  browser: {
+    asObject: true,
+    write: {
+      info: writeInfo,
+      warn: writeWarn,
+      error: writeError,
+      fatal: writeError,
+      debug: writeInfo,
+      trace: writeInfo,
     },
-    timestamp: () => `,"ts":"${new Date().toISOString()}"`,
   },
-  consoleDestination,
-);
+});
 
 export const logAccess = (fields: AccessFields): void => {
   const status = fields.status_code;

--- a/worker/observability/logger.ts
+++ b/worker/observability/logger.ts
@@ -1,0 +1,62 @@
+import pino from "pino";
+
+interface AccessFields {
+  method: string;
+  route: string;
+  status_code: number;
+  duration_ms: number;
+  request_id?: string;
+}
+
+const consoleDestination = {
+  write(chunk: string): void {
+    const line = chunk.endsWith("\n") ? chunk.slice(0, -1) : chunk;
+    let level: string | undefined;
+    try {
+      level = (JSON.parse(line) as { level?: string }).level;
+    } catch {
+      level = undefined;
+    }
+    if (level === "error" || level === "fatal") {
+      console.error(line);
+    } else if (level === "warn") {
+      console.warn(line);
+    } else {
+      // biome-ignore lint/suspicious/noConsole: pino destination — CF Workers Logs ingest console.log JSON
+      console.log(line);
+    }
+  },
+};
+
+export const logger = pino(
+  {
+    level: "info",
+    base: { service: "feed-finder" },
+    formatters: {
+      level: (label) => ({ level: label }),
+    },
+    timestamp: () => `,"ts":"${new Date().toISOString()}"`,
+  },
+  consoleDestination,
+);
+
+export const logAccess = (fields: AccessFields): void => {
+  const status = fields.status_code;
+  const payload = {
+    event: "http_access",
+    method: fields.method,
+    route: fields.route,
+    status_code: status,
+    duration_ms: Math.round(fields.duration_ms),
+    ...(fields.request_id !== undefined
+      ? { request_id: fields.request_id }
+      : {}),
+  };
+  if (status >= 500) {
+    logger.error(payload, "http_access");
+  } else if (status >= 400) {
+    logger.warn(payload, "http_access");
+  } else {
+    logger.info(payload, "http_access");
+  }
+};

--- a/worker/observability/pino-browser.d.ts
+++ b/worker/observability/pino-browser.d.ts
@@ -1,0 +1,6 @@
+// pino's package.json exposes a `browser` entry but ships no separate
+// type declarations; reuse the main pino types since the API surface
+// (default export, LoggerOptions) is identical.
+declare module "pino/browser" {
+  export { default } from "pino";
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,7 @@
   "name": "feed-finder",
   "main": "worker/index.ts",
   "compatibility_date": "2025-05-05",
+  "compatibility_flags": ["nodejs_compat"],
   "preview_urls": true,
   "assets": {
     "directory": "./dist",


### PR DESCRIPTION
## Overview

Cloudflare Workers Logs ingests `console.log`/`warn`/`error` output and forwards it to the Grafana Cloud drain configured in PR #52. To make those logs queryable (filter by `event`, `status_code`, `error_type`, etc.) the Worker needs to emit structured JSON instead of formatted strings.

This PR introduces a [pino](https://getpino.io/)-based logger that writes single-line JSON via the existing `console` channels, plus an `http_access` event recorded once per request with `method`, `route`, `status_code`, `duration_ms`, and the upstream `cf-ray` request ID. Error responses now log structured fields rather than ad-hoc strings, so the existing `error_id` is queryable in Loki / Cloudflare Workers Logs.

The dispatch logic in `worker/index.ts` is split into a small `dispatch()` helper so the access log wrapper can run uniformly for every code path (CORS preflight, API hit, 404).

## Related Issue

n/a

## Changes

- Add `pino` dependency and a `worker/observability/logger.ts` module that emits JSON via `console.log`/`warn`/`error` based on level
- Add `logAccess()` helper that emits `event=http_access` with method, route, status code, duration, and request ID; severity tracks the status code (info/warn/error)
- Refactor `worker/index.ts` to route every request through a `dispatch()` helper and log access at the boundary
- Switch `createErrorResponse` in `worker/http/errors.ts` to log structured fields (`error_id`, `error_type`, `details`)
- Enable `nodejs_compat` in `wrangler.jsonc` to satisfy pino's runtime requirements
- Add unit tests for the logger, the access log emitter, and the updated error-response logging

## Impact Scope

- Worker runtime only (no frontend changes)
- Log line format changes — any log-based dashboards or alerts that grep the previous `[id] Error type: ...` string will need to be updated to query the JSON fields
- Adds `nodejs_compat`; no other compatibility flags touched

## Checklist

- [x] Code follows the style guidelines (biome + typecheck pre-commit pass)
- [x] Tests have been added/updated
- [ ] Documentation has been updated (if relevant) — n/a
- [x] Build is successful
- [x] Ready for review

## How to Test

```bash
npm run test:run
npm run lint
npm run build
```

After deploy, hit any endpoint and confirm in Cloudflare Workers Logs / Grafana that each request produces an `event=http_access` JSON line with the expected fields, and that error paths produce `msg=error_response` with `error_type` populated.

## Additional Information

- pino is used as the structured-logging primitive only; we keep writing through `console.*` so Workers Logs / Grafana ingestion paths are unchanged. No worker-side transport, no extra fetch.
- A future change could move the level-routing logic from `consoleDestination` into a Workers-aware transport, but the current shape is the minimum needed to keep the existing log drain working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リクエストメソッド、ルート、ステータスコード、応答時間を含むアクセスログ機能を追加
  * エラーレスポンスに構造化されたロギング情報（エラーID、エラータイプ、詳細）を実装

* **チョア**
  * ロギング機能のための依存関係を更新
  * Cloudflare Workers互換性フラグを有効化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->