### PR TITLE
fix: Preserve Worker access logs

### DIFF
--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -1,0 +1,20 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import config from "./vite.config";
+
+describe("vite config", () => {
+  it("does not mark console.log as pure because Worker access logs use it", () => {
+    const pureFunctions =
+      config.build?.rollupOptions?.treeshake &&
+      typeof config.build.rollupOptions.treeshake === "object" &&
+      "manualPureFunctions" in config.build.rollupOptions.treeshake
+        ? config.build.rollupOptions.treeshake.manualPureFunctions
+        : [];
+
+    expect(pureFunctions).not.toContain("console.log");
+    expect(pureFunctions).toEqual(
+      expect.arrayContaining(["console.info", "console.debug"]),
+    );
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     // Code splitting configuration
     rollupOptions: {
       treeshake: {
-        manualPureFunctions: ["console.log", "console.info", "console.debug"],
+        manualPureFunctions: ["console.info", "console.debug"],
       },
       output: {
         manualChunks(id) {


### PR DESCRIPTION
## Overview

This fixes the production Worker access logs that were not reaching Loki after PR #56. The issue was not a Cloudflare or Grafana limitation: Cloudflare Workers OTel log export is documented to include application logs such as console.log output, and Grafana Cloud maps OTLP log bodies into Loki log lines.

The root cause was our Vite tree-shaking config. The same Vite config builds both the client and the Worker, and it marked console.log as a pure function. The Worker access logger emits successful 2xx access logs through pino/browser's info writer, which calls console.log. In the production Worker bundle, that call was stripped, so successful requests had no JSON access log to export.

This change keeps console.info and console.debug eligible for removal, but preserves console.log so Worker access logs survive production builds. It also adds a regression test for the Vite config.

## Related Issue

n/a

## Changes

- Remove console.log from Vite manual pure functions
- Add a regression test that prevents console.log from being marked pure again

## Impact Scope

- Affects production Worker build output and observability logs
- Keeps 2xx access logs emitted through console.log in the Worker bundle
- Does not change request handling, API behavior, or UI behavior

## Checklist

- [x] Code follows the style guidelines
- [x] Tests have been added/updated
- [ ] Documentation has been updated (if relevant)
- [x] Build is successful
- [x] Ready for review

## How to Test

- npm run test:run -- vite.config.test.ts worker/observability/logger.test.ts worker/index.access-log.test.ts
- npm run test:run
- npm run lint
- npm run build
- Confirmed the fresh Worker bundle contains the info-path console.log call: kt=e=>{console.log(Et(`info`,e))}
- Deployed this branch manually to Cloudflare Workers version 95058edc-daac-432f-b7b7-7307e694e940 before the history cleanup
- Confirmed wrangler tail --format=json showed JSON access logs for 200, 400, and 404 requests in the logs array

Note: npm run build exits 0, but Wrangler emits a sandbox-local EPERM warning while trying to write its debug log under ~/Library/Preferences/.wrangler/logs.

## Additional Information

The investigation document was intentionally removed from this PR history. The PR now contains only the Vite config fix and regression test.

Cloudflare runtime emission was verified manually. The remaining external confirmation is whether Grafana Cloud Loki receives the exported log records; no Grafana/Loki API token is exposed in this workspace environment, so that query was not run here.